### PR TITLE
PYSCAN-2: Add tests for the args parsing.

### DIFF
--- a/src/py_sonar_scanner/__main__.py
+++ b/src/py_sonar_scanner/__main__.py
@@ -17,6 +17,8 @@
 # along with this program; if not, write to the Free Software Foundation,
 # Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
+import sys
+
 from py_sonar_scanner.configuration import Configuration
 from py_sonar_scanner.environment import Environment
 

--- a/src/py_sonar_scanner/__main__.py
+++ b/src/py_sonar_scanner/__main__.py
@@ -17,7 +17,6 @@
 # along with this program; if not, write to the Free Software Foundation,
 # Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
-import sys
 
 from py_sonar_scanner.configuration import Configuration
 from py_sonar_scanner.environment import Environment

--- a/src/py_sonar_scanner/configuration.py
+++ b/src/py_sonar_scanner/configuration.py
@@ -37,42 +37,13 @@ class Configuration:
         self.sonar_scanner_executable_path = ""
         self.scan_arguments = []
 
-    def setup(self):
-        """This is executed when run from the command line"""
-        parser = argparse.ArgumentParser()
+    def setup(self) -> None:
+        """ This is executed when run from the command line """
 
-        # Required positional argument
-        parser.add_argument("arg", help="Required positional argument")
-
-        # Optional argument flag which defaults to False
-        parser.add_argument("-f", "--flag", action="store_true", default=False)
-
-        # Optional argument which requires a parameter (eg. -d test)
-        parser.add_argument("-n", "--name", action="store", dest="name")
-
-        # Optional verbosity counter (eg. -v, -vv, -vvv, etc.)
-        parser.add_argument("-v", "--verbose", action="count", default=0, help="Verbosity (-v, -vv, etc)")
-
-        # Specify output of "--version"
-        # parser.add_argument(
-        #     "--version",
-        #     action="version",
-        #     version="%(prog)s (version {version})".format(version=__version__))
-
-        # args = parser.parse_args()
-
-        scan_arguments = []
-        scan_arguments.extend(self._read_jvm_args())
+        scan_arguments = sys.argv[1:]
         scan_arguments.extend(self._read_toml_args())
 
         self.scan_arguments = scan_arguments
-
-    def _read_jvm_args(self) -> list[str]:
-        scan_arguments = []
-        for arg in sys.argv:
-            if arg.startswith("-D"):
-                scan_arguments.append(arg)
-        return scan_arguments
 
     def _read_toml_args(self) -> list[str]:
         scan_arguments: list[str] = []

--- a/src/py_sonar_scanner/configuration.py
+++ b/src/py_sonar_scanner/configuration.py
@@ -38,7 +38,7 @@ class Configuration:
         self.scan_arguments = []
 
     def setup(self) -> None:
-        """ This is executed when run from the command line """
+        """This is executed when run from the command line"""
 
         scan_arguments = sys.argv[1:]
         scan_arguments.extend(self._read_toml_args())

--- a/src/py_sonar_scanner/configuration.py
+++ b/src/py_sonar_scanner/configuration.py
@@ -18,7 +18,6 @@
 # Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
 from __future__ import annotations
-import argparse
 import os
 import sys
 from typing import Union

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -1,20 +1,34 @@
+#
+# Sonar Scanner Python
+# Copyright (C) 2011-2023 SonarSource SA.
+# mailto:info AT sonarsource DOT com
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 3 of the License, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful,
+#
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
 import unittest
 from unittest.mock import patch, Mock
 from py_sonar_scanner.configuration import Configuration
 
 
 class TestConfiguration(unittest.TestCase):
-
-    @patch('py_sonar_scanner.configuration.sys')
+    @patch("py_sonar_scanner.configuration.sys")
     def test_argument_parsing_empty_toml(self, mock_sys):
-
         configuration = Configuration()
         configuration._read_toml_args = Mock(return_value=[])
 
-        mock_sys.argv = [
-            "path/to/scanner/py-sonar-scanner",
-            "-DSomeJVMArg"
-        ]
+        mock_sys.argv = ["path/to/scanner/py-sonar-scanner", "-DSomeJVMArg"]
         configuration.setup()
         self.assertListEqual(configuration.scan_arguments, ["-DSomeJVMArg"])
 
@@ -26,9 +40,6 @@ class TestConfiguration(unittest.TestCase):
             "-SomeNonsense",
         ]
         configuration.setup()
-        self.assertListEqual(configuration.scan_arguments, [
-            "-DSomeJVMArg",
-            "-DAnotherJVMArg",
-            "-dNotAJVMArg",
-            "-SomeNonsense"
-        ])
+        self.assertListEqual(
+            configuration.scan_arguments, ["-DSomeJVMArg", "-DAnotherJVMArg", "-dNotAJVMArg", "-SomeNonsense"]
+        )

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -28,6 +28,10 @@ class TestConfiguration(unittest.TestCase):
         configuration = Configuration()
         configuration._read_toml_args = Mock(return_value=[])
 
+        mock_sys.argv = ["path/to/scanner/py-sonar-scanner"]
+        configuration.setup()
+        self.assertListEqual(configuration.scan_arguments, [])
+
         mock_sys.argv = ["path/to/scanner/py-sonar-scanner", "-DSomeJVMArg"]
         configuration.setup()
         self.assertListEqual(configuration.scan_arguments, ["-DSomeJVMArg"])

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -1,0 +1,34 @@
+import unittest
+from unittest.mock import patch, Mock
+from py_sonar_scanner.configuration import Configuration
+
+
+class TestConfiguration(unittest.TestCase):
+
+    @patch('py_sonar_scanner.configuration.sys')
+    def test_argument_parsing_empty_toml(self, mock_sys):
+
+        configuration = Configuration()
+        configuration._read_toml_args = Mock(return_value=[])
+
+        mock_sys.argv = [
+            "path/to/scanner/py-sonar-scanner",
+            "-DSomeJVMArg"
+        ]
+        configuration.setup()
+        self.assertListEqual(configuration.scan_arguments, ["-DSomeJVMArg"])
+
+        mock_sys.argv = [
+            "path/to/scanner/py-sonar-scanner",
+            "-DSomeJVMArg",
+            "-DAnotherJVMArg",
+            "-dNotAJVMArg",
+            "-SomeNonsense",
+        ]
+        configuration.setup()
+        self.assertListEqual(configuration.scan_arguments, [
+            "-DSomeJVMArg",
+            "-DAnotherJVMArg",
+            "-dNotAJVMArg",
+            "-SomeNonsense"
+        ])


### PR DESCRIPTION
Add test for jvm argument parsing.

Make passing of arguments clear.

Revert usage of sys.argv.