### PR TITLE
PYSCAN-31 Correct Configuration to look for the  table instead of the table in pyproject.toml

### DIFF
--- a/src/py_sonar_scanner/configuration.py
+++ b/src/py_sonar_scanner/configuration.py
@@ -65,11 +65,9 @@ class Configuration:
                 self._add_parameter_to_scanner_args(scan_arguments, f"{key}.{k}", v)
 
     def _read_toml_file(self) -> dict:
-        parsed_data: dict = {}
         if not os.path.isfile("pyproject.toml"):
-            return parsed_data
+            return {}
         with open("pyproject.toml", "r") as file:
             # TODO: actually search for pyproject.toml
             toml_data = file.read()
-            parsed_data = toml.loads(toml_data)
-        return parsed_data
+            return toml.loads(toml_data)

--- a/src/py_sonar_scanner/configuration.py
+++ b/src/py_sonar_scanner/configuration.py
@@ -47,16 +47,17 @@ class Configuration:
     def _read_toml_args(self) -> list[str]:
         scan_arguments: list[str] = []
         try:
-            if os.path.isfile("pyproject.toml"):
-                with open("pyproject.toml", "r") as file:
-                    # TODO: actually search for pyproject.toml
-                    toml_data = file.read()
-                    parsed_data = toml.loads(toml_data)
-                    print(parsed_data)
-                    if "sonar" in parsed_data:
-                        sonar_properties = parsed_data["sonar"]
-                        for key, value in sonar_properties.items():
-                            self._add_parameter_to_scanner_args(scan_arguments, key, value)
+            if not os.path.isfile("pyproject.toml"):
+                return scan_arguments
+            with open("pyproject.toml", "r") as file:
+                # TODO: actually search for pyproject.toml
+                toml_data = file.read()
+                parsed_data = toml.loads(toml_data)
+                if ("tool" not in parsed_data) or ("sonar" not in parsed_data["tool"]):
+                    return scan_arguments
+                sonar_properties = parsed_data["tool"]["sonar"]
+                for key, value in sonar_properties.items():
+                    self._add_parameter_to_scanner_args(scan_arguments, key, value)
         except BaseException as e:
             print(e)
         return scan_arguments


### PR DESCRIPTION
I have just changed the implementation here, and there are deliberately no tests associated because these will be done as part of PYSCAN-3. 