### PR TITLE
PYSCAN-3 Add tests for pyproject.toml file parsing.

### DIFF
--- a/src/py_sonar_scanner/configuration.py
+++ b/src/py_sonar_scanner/configuration.py
@@ -20,6 +20,8 @@
 from __future__ import annotations
 import os
 import sys
+from logging import Logger
+
 import toml
 
 from py_sonar_scanner.logger import ApplicationLogger
@@ -30,12 +32,14 @@ class Configuration:
     sonar_scanner_path: str
     sonar_scanner_version: str
     scan_arguments: list[str]
+    log: Logger
 
     def __init__(self):
         self.sonar_scanner_path = ".scanner"
         self.sonar_scanner_version = "4.6.2.2472"
         self.sonar_scanner_executable_path = ""
         self.scan_arguments = []
+        self.log = ApplicationLogger.get_logger()
 
     def setup(self) -> None:
         """This is executed when run from the command line"""
@@ -48,7 +52,7 @@ class Configuration:
         try:
             toml_data = self._read_toml_file()
         except OSError:
-            ApplicationLogger.get_logger().error("Test error while opening file.")
+            self.log.error("Test error while opening file.")
         sonar_properties = self._extract_sonar_properties(toml_data)
         for key, value in sonar_properties.items():
             self._add_parameter_to_scanner_args(scan_arguments, key, value)

--- a/tests/resources/test_toml_file.toml
+++ b/tests/resources/test_toml_file.toml
@@ -1,0 +1,10 @@
+[tool]
+ignored_property="something"
+
+[tool.sonar]
+property1="value1"
+property2="value2"
+
+[tool.sonar.property_class]
+property1="value1"
+

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -133,8 +133,6 @@ class TestConfiguration(unittest.TestCase):
     @patch("builtins.open")
     @patch("py_sonar_scanner.configuration.sys")
     def test_error_while_reading_toml_file(self, mock_sys, mock_open, mock_logger):
-        configuration = Configuration()
-
         mock_sys.argv = ["path/to/scanner/py-sonar-scanner"]
 
         mock_open.side_effect = OSError("Test error while opening file.")
@@ -143,6 +141,7 @@ class TestConfiguration(unittest.TestCase):
         mock_logger_instance.error = Mock()
         mock_logger.return_value = mock_logger_instance
 
+        configuration = Configuration()
         configuration.setup()
 
         self.assertListEqual(configuration.scan_arguments, [])

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -18,7 +18,7 @@
 # Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
 import unittest
-from unittest.mock import patch
+from unittest.mock import patch, Mock
 from py_sonar_scanner.configuration import Configuration
 
 
@@ -66,3 +66,84 @@ class TestConfiguration(unittest.TestCase):
         mock_sys.argv = ["path/to/scanner/py-sonar-scanner", "-Dproject.home=tests=2"]
         configuration.setup()
         self.assertListEqual(configuration.scan_arguments, ["-Dproject.home=tests=2"])
+
+    @patch("py_sonar_scanner.configuration.sys")
+    def test_dict_with_no_valid_values(self, mock_sys):
+        configuration = Configuration()
+        mock_sys.argv = ["path/to/scanner/py-sonar-scanner"]
+
+        test_dict = {}
+        configuration._read_toml_file = Mock(return_value=test_dict)
+        configuration.setup()
+        self.assertListEqual(configuration.scan_arguments, [])
+
+        test_dict = {"tool": "some_property"}
+        configuration._read_toml_file = Mock(return_value=test_dict)
+        configuration.setup()
+        self.assertListEqual(configuration.scan_arguments, [])
+
+        test_dict = {"tool": {"sonar": "some_property"}}
+        configuration._read_toml_file = Mock(return_value=test_dict)
+        configuration.setup()
+        self.assertListEqual(configuration.scan_arguments, [])
+
+    @patch("py_sonar_scanner.configuration.sys")
+    def test_dict_with_valid_values(self, mock_sys):
+        configuration = Configuration()
+        mock_sys.argv = ["path/to/scanner/py-sonar-scanner"]
+
+        test_dict = {"tool": {"sonar": {"property1": "value1"}}}
+        configuration._read_toml_file = Mock(return_value=test_dict)
+        configuration.setup()
+        self.assertListEqual(configuration.scan_arguments, ["-Dsonar.property1=value1"])
+
+        test_dict = {"tool": {"sonar": {"property1": "value1", "property2": "value2"}}}
+        configuration._read_toml_file = Mock(return_value=test_dict)
+        configuration.setup()
+        self.assertListEqual(configuration.scan_arguments, ["-Dsonar.property1=value1", "-Dsonar.property2=value2"])
+
+        test_dict = {"tool": {"sonar": {"property_class": {"property1": "value1"}}}}
+        configuration._read_toml_file = Mock(return_value=test_dict)
+        configuration.setup()
+        self.assertListEqual(configuration.scan_arguments, ["-Dsonar.property_class.property1=value1"])
+
+        test_dict = {"tool": {"sonar": {"property1": "value1", "property_class": {"sub_property": "sub_value"}}}}
+        configuration._read_toml_file = Mock(return_value=test_dict)
+        configuration.setup()
+        self.assertListEqual(
+            configuration.scan_arguments, ["-Dsonar.property1=value1", "-Dsonar.property_class.sub_property=sub_value"]
+        )
+
+    @patch("py_sonar_scanner.configuration.sys")
+    def test_toml_with_valid_values(self, mock_sys):
+        configuration = Configuration()
+        mock_sys.argv = ["path/to/scanner/py-sonar-scanner", "-Dtoml.path=tests/resources/test_toml_file.toml"]
+        configuration.setup()
+        self.assertListEqual(
+            configuration.scan_arguments,
+            [
+                "-Dtoml.path=tests/resources/test_toml_file.toml",
+                "-Dsonar.property1=value1",
+                "-Dsonar.property2=value2",
+                "-Dsonar.property_class.property1=value1",
+            ],
+        )
+
+    @patch("py_sonar_scanner.configuration.ApplicationLogger.get_logger")
+    @patch("builtins.open")
+    @patch("py_sonar_scanner.configuration.sys")
+    def test_error_while_reading_toml_file(self, mock_sys, mock_open, mock_logger):
+        configuration = Configuration()
+
+        mock_sys.argv = ["path/to/scanner/py-sonar-scanner"]
+
+        mock_open.side_effect = OSError("Test error while opening file.")
+
+        mock_logger_instance = Mock()
+        mock_logger_instance.error = Mock()
+        mock_logger.return_value = mock_logger_instance
+
+        configuration.setup()
+
+        self.assertListEqual(configuration.scan_arguments, [])
+        mock_logger_instance.error.assert_called_once_with("Test error while opening file.")


### PR DESCRIPTION
Right now I just do dictionary parsing. Therefore it remains for me to write tests to check that toml files get mapped correctly to dicts. 

Also, I don't look at how it interacts with the CLI arguments. I will take care of that later today. I nonetheless appreciate any review of the current tests. Thanks in advance!