### PR TITLE
PYSCAN-51 Add the virtual environment created specifically for the integration tests to the .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,6 +128,14 @@ ENV/
 env.bak/
 venv.bak/
 
+*/.env
+*/.venv
+*/env/
+*/venv/
+*/ENV/
+*/env.bak/
+*/venv.bak/
+
 # Spyder project settings
 .spyderproject
 .spyproject


### PR DESCRIPTION
So here I decided to omit any virtual environment created in the `its` directory, as per the ticket description. Another way would of course be to ignore any environment created in any subdirectory. Essentially replacing the `its` with `*`. Would this make more sense perhaps? LMKWYT.