### PR TITLE
BUILD-5727 Use JDK21 LTS instead of JDK18 EOL

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -51,7 +51,7 @@ mend_scan_task:
   # run only on master and long-living branches
   only_if: $CIRRUS_USER_COLLABORATOR == 'true' && $CIRRUS_TAG == "" && ($CIRRUS_BRANCH == "master" || $CIRRUS_BRANCH =~ "branch-.*")
   eks_container:
-    image: ${CIRRUS_AWS_ACCOUNT}.dkr.ecr.eu-central-1.amazonaws.com/base:j18-latest
+    image: ${CIRRUS_AWS_ACCOUNT}.dkr.ecr.eu-central-1.amazonaws.com/base:j21-latest
     region: eu-central-1
     cluster_name: ${CIRRUS_CLUSTER_NAME}
     namespace: default


### PR DESCRIPTION
## Changes

- [x] Cirrus CI use now JDK21 LTS instead of EOL JDK18
      That way it keeps working (ci-docker-images will no longer produce JDK18 images as it is EOL)