### PR TITLE
SONARPY-87: Configure Github action to not create Jira tickets for renovate PRs

### DIFF
--- a/.github/workflows/PullRequestCreated.yml
+++ b/.github/workflows/PullRequestCreated.yml
@@ -13,6 +13,8 @@ jobs:
     # For external PR, ticket should be created manually
     if: |
         github.event.pull_request.head.repo.full_name == github.repository
+        && github.event.sender.type != 'Bot'
+        && ${{ !startsWith(github.event.pull_request.title, 'NO-JIRA') }}
     steps:
       - id: secrets
         uses: SonarSource/vault-action-wrapper@v3


### PR DESCRIPTION
[SONARPY-87](https://sonarsource.atlassian.net/browse/SONARPY-87)

Part of 
<!-- 
  Only for standalone PRs without Jira issue in the PR title: 
    * Replace this comment with Epic ID to create a new Task in Jira
    * Replace this comment with Issue ID to create a new Sub-Task in Jira
    * Ignore or delete this note to create a new Task in Jira without a parent 
-->

[SONARPY-87]: https://sonarsource.atlassian.net/browse/SONARPY-87?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ