### PR TITLE
SCANPY-118 Use functioning py-sonar-scanner instead of the branch version

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -84,7 +84,7 @@ analysis_task:
     - poetry run pytest --cov-report=xml:coverage.xml --cov-config=pyproject.toml --cov=src --cov-branch tests
     - uv venv
     - source .venv/bin/activate
-    - uv pip install .
+    - uv pip install pysonar-scanner
     - pysonar-scanner -Dsonar.organization=sonarsource -DbuildNumber=${CI_BUILD_NUMBER}
   always:
     pytest_artifacts:


### PR DESCRIPTION
[SCANPY-118](https://sonarsource.atlassian.net/browse/SCANPY-118)

Part of SCANPY-98

[SCANPY-118]: https://sonarsource.atlassian.net/browse/SCANPY-118?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ