### PR TITLE
SCANPY-75: Added releasability task to CI

### DIFF
--- a/.github/workflows/releasability.yml
+++ b/.github/workflows/releasability.yml
@@ -1,0 +1,30 @@
+name: Releasability status
+"on":
+  check_suite:
+    types:
+      - completed
+  workflow_dispatch:
+
+jobs:
+  update_releasability_status:
+    runs-on: ubuntu-latest
+    name: Releasability status
+    permissions:
+      id-token: write
+      statuses: write
+      contents: read
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      ((contains(fromJSON('["main", "master"]'),
+      github.event.check_suite.head_branch) ||
+      startsWith(github.event.check_suite.head_branch, 'branch-')) &&
+      github.event.check_suite.conclusion == 'success' &&
+      github.event.check_suite.app.slug == 'cirrus-ci')
+    steps:
+      - uses: >-
+          SonarSource/gh-action_releasability/releasability-status@v2
+        with:
+          # CheckManifestValues is not supported for python projects (see PREQ-465)
+          optional_checks: "Jira,CheckManifestValues"
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
[SCANPY-75](https://sonarsource.atlassian.net/browse/SCANPY-75)

This PR introduces the releasability check in the sonar-scanner-python repository. Unfortunately, the releasability GitHub action doesn't fully support python projects (see [PREQ-456](https://sonarsource.atlassian.net/browse/PREQ-465)) and, therefore, the `CheckManifestValues` check has to be ignored as it always fails.

See [this](https://github.com/SonarSource/sonar-scanner-python/actions/runs/13994360330/job/39185620439) successful pipeline run.

Also, note: this pipeline still uses the ubuntu-latest runner instead of the sonar-runner. The sonar-scanner-python project hasn't been on boarded yet to use the new runenrs. However, this should be done as part of [SCANPY-154](https://sonarsource.atlassian.net/browse/SCANPY-154)

[SCANPY-75]: https://sonarsource.atlassian.net/browse/SCANPY-75?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PREQ-456]: https://sonarsource.atlassian.net/browse/PREQ-456?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[SCANPY-154]: https://sonarsource.atlassian.net/browse/SCANPY-154?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ