### PR TITLE
SCANPY-114 Parse the scanner properties from the environnement variables

### DIFF
--- a/src/pysonar_scanner/configuration/configuration_loader.py
+++ b/src/pysonar_scanner/configuration/configuration_loader.py
@@ -23,7 +23,7 @@ from pysonar_scanner.configuration.cli import CliConfigurationLoader
 from pysonar_scanner.configuration.pyproject_toml import TomlConfigurationLoader
 from pysonar_scanner.configuration.properties import SONAR_TOKEN, SONAR_PROJECT_BASE_DIR, Key
 from pysonar_scanner.configuration.properties import PROPERTIES
-from pysonar_scanner.configuration import sonar_project_properties
+from pysonar_scanner.configuration import sonar_project_properties, environment_variables
 
 from pysonar_scanner.exceptions import MissingKeyException
 
@@ -51,6 +51,7 @@ class ConfigurationLoader:
         resolved_properties.update(toml_properties.project_properties)
         resolved_properties.update(sonar_project_properties.load(base_dir))
         resolved_properties.update(toml_properties.sonar_properties)
+        resolved_properties.update(environment_variables.load())
         resolved_properties.update(cli_properties)
         return resolved_properties
 

--- a/src/pysonar_scanner/configuration/environment_variables.py
+++ b/src/pysonar_scanner/configuration/environment_variables.py
@@ -1,0 +1,40 @@
+#
+# Sonar Scanner Python
+# Copyright (C) 2011-2024 SonarSource SA.
+# mailto:info AT sonarsource DOT com
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 3 of the License, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful,
+#
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+import os
+from typing import Dict
+
+from pysonar_scanner.configuration.properties import Key, PROPERTIES
+
+
+def load() -> Dict[Key, str]:
+    """
+    Load configuration properties from environment variables.
+
+    Returns:
+        Dictionary of property keys and their values extracted from environment variables.
+    """
+    properties = {}
+    # Extract properties from environment variables using the env_variable_name() method
+    for prop in PROPERTIES:
+        env_var_name = prop.env_variable_name()
+        if env_var_name in os.environ:
+            properties[prop.name] = os.environ[env_var_name]
+
+    return properties

--- a/src/pysonar_scanner/configuration/properties.py
+++ b/src/pysonar_scanner/configuration/properties.py
@@ -88,6 +88,21 @@ class Property:
             result.append(char.lower())
         return "".join(result)
 
+    def env_variable_name(self) -> str:
+        """Convert property name to environment variable name format.
+        Example: sonar.scanner.proxyPort -> SONAR_SCANNER_PROXY_PORT"""
+        # Replace dots with underscores
+        env_name = self.name.replace(".", "_")
+
+        # Insert underscores before uppercase letters (camelCase to snake_case)
+        result = []
+        for i, char in enumerate(env_name):
+            if char.isupper() and i > 0 and env_name[i - 1] != "_":
+                result.append("_")
+            result.append(char)
+        # Convert to uppercase
+        return "".join(result).upper()
+
 
 # fmt: off
 PROPERTIES: list[Property] = [

--- a/tests/test_environment_variables.py
+++ b/tests/test_environment_variables.py
@@ -1,0 +1,93 @@
+#
+# Sonar Scanner Python
+# Copyright (C) 2011-2024 SonarSource SA.
+# mailto:info AT sonarsource DOT com
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 3 of the License, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful,
+#
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+import unittest
+from unittest.mock import patch
+
+from pysonar_scanner.configuration import environment_variables
+from pysonar_scanner.configuration.properties import (
+    SONAR_HOST_URL,
+    SONAR_REGION,
+    SONAR_SCANNER_ARCH,
+    SONAR_SCANNER_JAVA_OPTS,
+    SONAR_SCANNER_OS,
+    SONAR_TOKEN,
+    SONAR_USER_HOME,
+    SONAR_PROJECT_KEY,
+)
+
+
+class TestEnvironmentVariables(unittest.TestCase):
+    def setUp(self):
+        self.maxDiff = None
+
+    def test_empty_environment(self):
+        with patch.dict("os.environ", {}, clear=True):
+            properties = environment_variables.load()
+            self.assertEqual(len(properties), 0)
+            self.assertDictEqual(properties, {})
+
+    def test__environment_variables(self):
+        env = {
+            "SONAR_TOKEN": "my-token",
+            "SONAR_HOST_URL": "https://sonarqube.example.com",
+            "SONAR_USER_HOME": "/custom/sonar/home",
+            "SONAR_SCANNER_JAVA_OPTS": "-Xmx1024m -XX:MaxPermSize=256m",
+            "SONAR_REGION": "us",
+        }
+        with patch.dict("os.environ", env, clear=True):
+            properties = environment_variables.load()
+            expected_properties = {
+                SONAR_TOKEN: "my-token",
+                SONAR_HOST_URL: "https://sonarqube.example.com",
+                SONAR_USER_HOME: "/custom/sonar/home",
+                SONAR_SCANNER_JAVA_OPTS: "-Xmx1024m -XX:MaxPermSize=256m",
+                SONAR_REGION: "us",
+            }
+            self.assertEqual(len(properties), 5)
+            self.assertDictEqual(properties, expected_properties)
+
+    def test_irrelevant_environment_variables(self):
+        env = {"UNRELATED_VAR": "some-value", "PATH": "/usr/bin:/bin", "HOME": "/home/user"}
+        with patch.dict("os.environ", env, clear=True):
+            properties = environment_variables.load()
+            self.assertEqual(len(properties), 0)
+            self.assertDictEqual(properties, {})
+
+    def test_mixed_environment_variables(self):
+        env = {
+            "SONAR_TOKEN": "my-token",
+            "SONAR_HOST_URL": "https://sonarqube.example.com",
+            "SONAR_PROJECT_KEY": "MyProjectKey",
+            "UNRELATED_VAR": "some-value",
+            "SONAR_SCANNER_OS": "linux",
+            "SONAR_SCANNER_ARCH": "x64",
+            "PATH": "/usr/bin:/bin",
+        }
+        with patch.dict("os.environ", env, clear=True):
+            properties = environment_variables.load()
+            expected_properties = {
+                SONAR_TOKEN: "my-token",
+                SONAR_HOST_URL: "https://sonarqube.example.com",
+                SONAR_PROJECT_KEY: "MyProjectKey",
+                SONAR_SCANNER_OS: "linux",
+                SONAR_SCANNER_ARCH: "x64",
+            }
+            self.assertEqual(len(properties), 5)
+            self.assertDictEqual(properties, expected_properties)

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -1,0 +1,107 @@
+#
+# Sonar Scanner Python
+# Copyright (C) 2011-2024 SonarSource SA.
+# mailto:info AT sonarsource DOT com
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 3 of the License, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful,
+#
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+
+import unittest
+
+from pysonar_scanner.configuration.properties import (
+    Property,
+    SONAR_HOST_URL,
+    SONAR_TOKEN,
+    SONAR_VERBOSE,
+    SONAR_SCANNER_APP_VERSION,
+    SONAR_SCANNER_SOCKET_TIMEOUT,
+    SONAR_SCANNER_PROXY_PASSWORD,
+    SONAR_SCANNER_INTERNAL_DUMP_TO_FILE,
+    SONAR_PROJECT_KEY,
+    SONAR_PROJECT_BASE_DIR,
+    PROPERTIES,
+)
+
+
+class TestProperties(unittest.TestCase):
+    def test_python_name_conversion(self):
+        """Test conversion of property names to Python-style kebab-case names"""
+        test_cases = [
+            # Simple properties
+            (SONAR_HOST_URL, "sonar.host.url"),
+            (SONAR_TOKEN, "sonar.token"),
+            (SONAR_VERBOSE, "sonar.verbose"),
+            # CamelCase properties
+            (SONAR_SCANNER_APP_VERSION, "sonar.scanner.app-version"),
+            (SONAR_SCANNER_SOCKET_TIMEOUT, "sonar.scanner.socket-timeout"),
+            (SONAR_SCANNER_PROXY_PASSWORD, "sonar.scanner.proxy-password"),
+            # Complex properties
+            (SONAR_SCANNER_INTERNAL_DUMP_TO_FILE, "sonar.scanner.internal.dump-to-file"),
+            (SONAR_PROJECT_KEY, "sonar.project-key"),
+            (SONAR_PROJECT_BASE_DIR, "sonar.project-base-dir"),
+        ]
+
+        for name, expected_python_name in test_cases:
+            # Find property in PROPERTIES list
+            prop = next((p for p in PROPERTIES if p.name == name), None)
+            if prop:
+                self.assertEqual(
+                    prop.python_name(),
+                    expected_python_name,
+                    f"Failed to convert {name} to Python name, got {prop.python_name()}",
+                )
+            else:
+                # Create test property if not in list
+                prop = Property(name=name, default_value=None)
+                self.assertEqual(
+                    prop.python_name(),
+                    expected_python_name,
+                    f"Failed to convert {name} to Python name, got {prop.python_name()}",
+                )
+
+    def test_env_variable_name_conversion(self):
+        """Test conversion of property names to environment variable format"""
+        test_cases = [
+            # Simple properties
+            (SONAR_HOST_URL, "SONAR_HOST_URL"),
+            (SONAR_TOKEN, "SONAR_TOKEN"),
+            (SONAR_VERBOSE, "SONAR_VERBOSE"),
+            # CamelCase properties
+            (SONAR_SCANNER_APP_VERSION, "SONAR_SCANNER_APP_VERSION"),
+            (SONAR_SCANNER_SOCKET_TIMEOUT, "SONAR_SCANNER_SOCKET_TIMEOUT"),
+            (SONAR_SCANNER_PROXY_PASSWORD, "SONAR_SCANNER_PROXY_PASSWORD"),
+            # Complex properties
+            (SONAR_SCANNER_INTERNAL_DUMP_TO_FILE, "SONAR_SCANNER_INTERNAL_DUMP_TO_FILE"),
+            (SONAR_PROJECT_KEY, "SONAR_PROJECT_KEY"),
+            (SONAR_PROJECT_BASE_DIR, "SONAR_PROJECT_BASE_DIR"),
+        ]
+
+        for name, expected_env_name in test_cases:
+            # Find property in PROPERTIES list
+            prop = next((p for p in PROPERTIES if p.name == name), None)
+            if prop:
+                self.assertEqual(
+                    prop.env_variable_name(),
+                    expected_env_name,
+                    f"Failed to convert {name} to environment variable name, got {prop.env_variable_name()}",
+                )
+            else:
+                # Create test property if not in list
+                prop = Property(name=name, default_value=None)
+                self.assertEqual(
+                    prop.env_variable_name(),
+                    expected_env_name,
+                    f"Failed to convert {name} to environment variable name, got {prop.env_variable_name()}",
+                )


### PR DESCRIPTION
[SCANPY-114](https://sonarsource.atlassian.net/browse/SCANPY-114)


Note: this is based on SCANPY-139 branch, which probably should be reviewed first (although both changes can be reviewed independently - the goal is to avoid merge conflicts).

[SCANPY-114]: https://sonarsource.atlassian.net/browse/SCANPY-114?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ