### PR TITLE
SCANPY-145 Dynamically infer the OS and Architecture properties

### DIFF
--- a/src/pysonar_scanner/api.py
+++ b/src/pysonar_scanner/api.py
@@ -32,7 +32,7 @@ from pysonar_scanner.configuration.properties import (
     Key,
 )
 from pysonar_scanner.exceptions import MissingKeyException, SonarQubeApiException
-from pysonar_scanner.utils import Arch, Os, remove_trailing_slash
+from pysonar_scanner.utils import remove_trailing_slash, OsStr, ArchStr
 
 
 @dataclass(frozen=True)
@@ -211,12 +211,9 @@ class SonarQubeApi:
         except requests.RequestException as e:
             raise SonarQubeApiException("Error while fetching the analysis engine") from e
 
-    def get_analysis_jres(self, os: Optional[Os] = None, arch: Optional[Arch] = None) -> list[JRE]:
+    def get_analysis_jres(self, os: OsStr, arch: ArchStr) -> list[JRE]:
         try:
-            params = {
-                "os": os.value if os else None,
-                "arch": arch.value if arch else None,
-            }
+            params = {"os": os, "arch": arch}
             res = requests.get(
                 f"{self.base_urls.api_base_url}/analysis/jres",
                 auth=self.auth,

--- a/src/pysonar_scanner/configuration/configuration_loader.py
+++ b/src/pysonar_scanner/configuration/configuration_loader.py
@@ -23,7 +23,7 @@ from pysonar_scanner.configuration.cli import CliConfigurationLoader
 from pysonar_scanner.configuration.pyproject_toml import TomlConfigurationLoader
 from pysonar_scanner.configuration.properties import SONAR_TOKEN, SONAR_PROJECT_BASE_DIR, Key
 from pysonar_scanner.configuration.properties import PROPERTIES
-from pysonar_scanner.configuration import sonar_project_properties, environment_variables
+from pysonar_scanner.configuration import sonar_project_properties, environment_variables, dynamic_defaults_loader
 
 from pysonar_scanner.exceptions import MissingKeyException
 
@@ -38,6 +38,7 @@ class ConfigurationLoader:
         # each property loader is required to return NO default values.
         # E.g. if no property has been set, an empty dict must be returned.
         # Default values should be set through the get_static_default_properties() method
+
         cli_properties = CliConfigurationLoader.load()
         # CLI properties have a higher priority than properties file,
         # but we need to resolve them first to load the properties file
@@ -48,6 +49,7 @@ class ConfigurationLoader:
         toml_properties = TomlConfigurationLoader.load(toml_dir)
 
         resolved_properties = get_static_default_properties()
+        resolved_properties.update(dynamic_defaults_loader.load())
         resolved_properties.update(toml_properties.project_properties)
         resolved_properties.update(sonar_project_properties.load(base_dir))
         resolved_properties.update(toml_properties.sonar_properties)

--- a/src/pysonar_scanner/configuration/dynamic_defaults_loader.py
+++ b/src/pysonar_scanner/configuration/dynamic_defaults_loader.py
@@ -29,8 +29,8 @@ def load() -> Dict[Key, any]:
     Load dynamically computed default properties
     """
     properties = {
-        SONAR_SCANNER_OS: utils.get_os(),
-        SONAR_SCANNER_ARCH: utils.get_arch(),
+        SONAR_SCANNER_OS: utils.get_os().value,
+        SONAR_SCANNER_ARCH: utils.get_arch().value,
         SONAR_PROJECT_BASE_DIR: os.getcwd(),
     }
     return properties

--- a/src/pysonar_scanner/configuration/dynamic_defaults_loader.py
+++ b/src/pysonar_scanner/configuration/dynamic_defaults_loader.py
@@ -1,0 +1,36 @@
+#
+# Sonar Scanner Python
+# Copyright (C) 2011-2024 SonarSource SA.
+# mailto:info AT sonarsource DOT com
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 3 of the License, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful,
+#
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+import os
+from typing import Dict
+
+from pysonar_scanner.configuration.properties import Key, SONAR_SCANNER_OS, SONAR_SCANNER_ARCH, SONAR_PROJECT_BASE_DIR
+from pysonar_scanner import utils
+
+
+def load() -> Dict[Key, any]:
+    """
+    Load dynamically computed default properties
+    """
+    properties = {
+        SONAR_SCANNER_OS: utils.get_os(),
+        SONAR_SCANNER_ARCH: utils.get_arch(),
+        SONAR_PROJECT_BASE_DIR: os.getcwd(),
+    }
+    return properties

--- a/src/pysonar_scanner/configuration/properties.py
+++ b/src/pysonar_scanner/configuration/properties.py
@@ -178,7 +178,7 @@ PROPERTIES: list[Property] = [
     ),
     Property(
         name=SONAR_USER_HOME, 
-        default_value="~/.sonar", 
+        default_value=None,
         cli_getter=lambda args: args.sonar_user_home
     ),  
     Property(

--- a/src/pysonar_scanner/jre.py
+++ b/src/pysonar_scanner/jre.py
@@ -53,9 +53,11 @@ class JREResolvedPath:
 
 
 class JREProvisioner:
-    def __init__(self, api: SonarQubeApi, cache: Cache):
+    def __init__(self, api: SonarQubeApi, cache: Cache, sonar_scanner_os: str, sonar_scanner_arch: str):
         self.api = api
         self.cache = cache
+        self.sonar_scanner_os = sonar_scanner_os
+        self.sonar_scanner_arch = sonar_scanner_arch
 
     def provision(self) -> JREResolvedPath:
         jre, resolved_path = self.__attempt_provisioning_jre_with_retry()
@@ -67,7 +69,7 @@ class JREProvisioner:
             jre_and_resolved_path = self.__attempt_provisioning_jre()
         if jre_and_resolved_path is None:
             raise ChecksumException(
-                f"Failed to download and verify JRE for {utils.get_os().value} and {utils.get_arch().value}"
+                f"Failed to download and verify JRE for {self.sonar_scanner_os} and {self.sonar_scanner_arch}"
             )
 
         return jre_and_resolved_path
@@ -83,10 +85,10 @@ class JREProvisioner:
         return (jre, jre_path) if jre_path is not None else None
 
     def __get_available_jre(self) -> JRE:
-        jres = self.api.get_analysis_jres(os=utils.get_os(), arch=utils.get_arch())
+        jres = self.api.get_analysis_jres(os=self.sonar_scanner_os, arch=self.sonar_scanner_arch)
         if len(jres) == 0:
             raise NoJreAvailableException(
-                f"No JREs are available for {utils.get_os().value} and {utils.get_arch().value}"
+                f"No JREs are available for {self.sonar_scanner_os} and {self.sonar_scanner_arch}"
             )
         return jres[0]
 

--- a/src/pysonar_scanner/scannerengine.py
+++ b/src/pysonar_scanner/scannerengine.py
@@ -31,6 +31,7 @@ import pysonar_scanner.api as api
 
 from pysonar_scanner.api import SonarQubeApi
 from pysonar_scanner.cache import Cache, CacheFile
+from pysonar_scanner.configuration.properties import SONAR_SCANNER_OS, SONAR_SCANNER_ARCH
 from pysonar_scanner.exceptions import ChecksumException, SQTooOldException
 from pysonar_scanner.jre import JREProvisioner, JREResolvedPath, JREResolver, JREResolverConfiguration
 from subprocess import Popen, PIPE
@@ -175,6 +176,6 @@ class ScannerEngine:
             )
 
     def __resolve_jre(self, config: dict[str, any]) -> JREResolvedPath:
-        jre_provisionner = JREProvisioner(self.api, self.cache)
+        jre_provisionner = JREProvisioner(self.api, self.cache, config[SONAR_SCANNER_OS], config[SONAR_SCANNER_ARCH])
         jre_resolver = JREResolver(JREResolverConfiguration.from_dict(config), jre_provisionner)
         return jre_resolver.resolve_jre()

--- a/src/pysonar_scanner/utils.py
+++ b/src/pysonar_scanner/utils.py
@@ -21,7 +21,9 @@ import hashlib
 import pathlib
 import platform
 import typing
-from enum import Enum
+
+OsStr = typing.Literal["windows", "linux", "mac", "alpine", "other"]
+ArchStr = typing.Literal["x86_64", "aarch64", "x86"]
 
 
 def remove_trailing_slash(url: str) -> str:
@@ -35,15 +37,7 @@ def calculate_checksum(filehandle: typing.BinaryIO) -> str:
     return sha256_hash.hexdigest()
 
 
-class Os(Enum):
-    WINDOWS = "windows"
-    LINUX = "linux"
-    MACOS = "mac"
-    ALPINE = "alpine"
-    OTHER = "other"
-
-
-def get_os() -> Os:
+def get_os() -> OsStr:
     def is_alpine() -> bool:
         try:
             os_release = pathlib.Path("/etc/os-release")
@@ -58,30 +52,24 @@ def get_os() -> Os:
 
     os_name = platform.system()
     if os_name == "Windows":
-        return Os.WINDOWS
+        return "windows"
     elif os_name == "Darwin":
-        return Os.MACOS
+        return "mac"
     elif os_name == "Linux":
         if is_alpine():
-            return Os.ALPINE
+            return "alpine"
         else:
-            return Os.LINUX
-    return Os.OTHER
+            return "linux"
+    return "other"
 
 
-class Arch(Enum):
-    X64 = "x64"
-    AARCH64 = "aarch64"
-    OTHER = "other"
-
-
-def get_arch() -> Arch:
+def get_arch() -> ArchStr:
     machine = platform.machine().lower()
     if machine in ["amd64", "x86_64"]:
-        return Arch.X64
+        return "x64"
     elif machine == "arm64":
-        return Arch.AARCH64
-    return Arch.OTHER
+        return "aarch64"
+    return "other"
 
 
 def filter_none_values(dictionary: dict) -> dict:

--- a/src/pysonar_scanner/utils.py
+++ b/src/pysonar_scanner/utils.py
@@ -21,6 +21,7 @@ import hashlib
 import pathlib
 import platform
 import typing
+from enum import Enum
 
 OsStr = typing.Literal["windows", "linux", "mac", "alpine", "other"]
 ArchStr = typing.Literal["x86_64", "aarch64", "x86"]
@@ -37,7 +38,15 @@ def calculate_checksum(filehandle: typing.BinaryIO) -> str:
     return sha256_hash.hexdigest()
 
 
-def get_os() -> OsStr:
+class Os(Enum):
+    WINDOWS: OsStr = "windows"
+    LINUX: OsStr = "linux"
+    MACOS: OsStr = "mac"
+    ALPINE: OsStr = "alpine"
+    OTHER: OsStr = "other"
+
+
+def get_os() -> Os:
     def is_alpine() -> bool:
         try:
             os_release = pathlib.Path("/etc/os-release")
@@ -52,24 +61,30 @@ def get_os() -> OsStr:
 
     os_name = platform.system()
     if os_name == "Windows":
-        return "windows"
+        return Os.WINDOWS
     elif os_name == "Darwin":
-        return "mac"
+        return Os.MACOS
     elif os_name == "Linux":
         if is_alpine():
-            return "alpine"
+            return Os.ALPINE
         else:
-            return "linux"
-    return "other"
+            return Os.LINUX
+    return Os.OTHER
 
 
-def get_arch() -> ArchStr:
+class Arch(Enum):
+    X64: ArchStr = "x64"
+    AARCH64: ArchStr = "aarch64"
+    OTHER: ArchStr = "other"
+
+
+def get_arch() -> Arch:
     machine = platform.machine().lower()
     if machine in ["amd64", "x86_64"]:
-        return "x64"
+        return Arch.X64
     elif machine == "arm64":
-        return "aarch64"
-    return "other"
+        return Arch.AARCH64
+    return Arch.OTHER
 
 
 def filter_none_values(dictionary: dict) -> dict:

--- a/src/pysonar_scanner/utils.py
+++ b/src/pysonar_scanner/utils.py
@@ -24,7 +24,7 @@ import typing
 from enum import Enum
 
 OsStr = typing.Literal["windows", "linux", "mac", "alpine", "other"]
-ArchStr = typing.Literal["x86_64", "aarch64", "x86"]
+ArchStr = typing.Literal["x64", "aarch64", "other"]
 
 
 def remove_trailing_slash(url: str) -> str:

--- a/tests/sq_api_utils.py
+++ b/tests/sq_api_utils.py
@@ -80,6 +80,8 @@ class SQApiMocker:
         self,
         body: Optional[list[dict]] = None,
         status: int = 200,
+        os_matcher: Optional[str] = "linux",
+        arch_matcher: Optional[str] = "x64",
     ) -> responses.BaseResponse:
         return self.rsps.get(
             url=f"{self.api_url}/analysis/jres",
@@ -87,6 +89,7 @@ class SQApiMocker:
             status=status,
             match=[
                 matchers.header_matcher({"Accept": "application/json"}),
+                matchers.query_param_matcher(utils.filter_none_values({"os": os_matcher, "arch": arch_matcher})),
             ],
         )
 

--- a/tests/sq_api_utils.py
+++ b/tests/sq_api_utils.py
@@ -79,8 +79,6 @@ class SQApiMocker:
     def mock_analysis_jres(
         self,
         body: Optional[list[dict]] = None,
-        os_matcher: Optional[str] = None,
-        arch_matcher: Optional[str] = None,
         status: int = 200,
     ) -> responses.BaseResponse:
         return self.rsps.get(
@@ -89,7 +87,6 @@ class SQApiMocker:
             status=status,
             match=[
                 matchers.header_matcher({"Accept": "application/json"}),
-                matchers.query_param_matcher(utils.filter_none_values({"os": os_matcher, "arch": arch_matcher})),
             ],
         )
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -320,7 +320,7 @@ class TestSonarQubeApi(unittest.TestCase):
         with self.subTest("get_analysis_jres works"), sq_api_mocker() as mocker:
             mocker.mock_analysis_jres([sq_api_utils.jre_to_dict(jre) for jre in expected_jres])
 
-            actual_jres = self.sq.get_analysis_jres()
+            actual_jres = self.sq.get_analysis_jres(os="linux", arch="x86_64")
             self.assertEqual(actual_jres, expected_jres)
 
         with (
@@ -329,7 +329,7 @@ class TestSonarQubeApi(unittest.TestCase):
             self.assertRaises(SonarQubeApiException),
         ):
             mocker.mock_analysis_jres(status=404)
-            self.sq.get_analysis_jres()
+            self.sq.get_analysis_jres(os="linux", arch="x86_64")
 
         with (
             self.subTest("get_analysis_jres returns error when keys are missing"),
@@ -337,7 +337,7 @@ class TestSonarQubeApi(unittest.TestCase):
             self.assertRaises(SonarQubeApiException),
         ):
             mocker.mock_analysis_jres([{"id": "jre1"}])
-            self.sq.get_analysis_jres()
+            self.sq.get_analysis_jres(os="linux", arch="x86_64")
 
     def test_download_analysis_jre(self):
         jre_id = "jre1"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -317,10 +317,17 @@ class TestSonarQubeApi(unittest.TestCase):
             ),
         ]
 
-        with self.subTest("get_analysis_jres works"), sq_api_mocker() as mocker:
+        with self.subTest("get_analysis_jres works (linux)"), sq_api_mocker() as mocker:
             mocker.mock_analysis_jres([sq_api_utils.jre_to_dict(jre) for jre in expected_jres])
 
-            actual_jres = self.sq.get_analysis_jres(os="linux", arch="x86_64")
+            actual_jres = self.sq.get_analysis_jres(os="linux", arch="x64")
+            self.assertEqual(actual_jres, expected_jres)
+
+        with self.subTest("get_analysis_jres works (windows)"), sq_api_mocker() as mocker:
+            mocker.mock_analysis_jres(
+                [sq_api_utils.jre_to_dict(jre) for jre in expected_jres], os_matcher="windows", arch_matcher="aarch64"
+            )
+            actual_jres = self.sq.get_analysis_jres(os="windows", arch="aarch64")
             self.assertEqual(actual_jres, expected_jres)
 
         with (
@@ -329,7 +336,7 @@ class TestSonarQubeApi(unittest.TestCase):
             self.assertRaises(SonarQubeApiException),
         ):
             mocker.mock_analysis_jres(status=404)
-            self.sq.get_analysis_jres(os="linux", arch="x86_64")
+            self.sq.get_analysis_jres(os="linux", arch="x64")
 
         with (
             self.subTest("get_analysis_jres returns error when keys are missing"),
@@ -337,7 +344,7 @@ class TestSonarQubeApi(unittest.TestCase):
             self.assertRaises(SonarQubeApiException),
         ):
             mocker.mock_analysis_jres([{"id": "jre1"}])
-            self.sq.get_analysis_jres(os="linux", arch="x86_64")
+            self.sq.get_analysis_jres(os="linux", arch="x64")
 
     def test_download_analysis_jre(self):
         jre_id = "jre1"

--- a/tests/test_configuration_loader.py
+++ b/tests/test_configuration_loader.py
@@ -17,7 +17,7 @@
 # along with this program; if not, write to the Free Software Foundation,
 # Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
-
+import os
 from unittest.mock import patch
 
 import pyfakefs.fake_filesystem_unittest as pyfakefs
@@ -26,6 +26,7 @@ from pysonar_scanner.configuration import configuration_loader
 from pysonar_scanner.configuration.properties import (
     SONAR_PROJECT_KEY,
     SONAR_PROJECT_NAME,
+    SONAR_PROJECT_BASE_DIR,
     SONAR_SCANNER_APP,
     SONAR_SCANNER_APP_VERSION,
     SONAR_SCANNER_BOOTSTRAP_START_TIME,
@@ -49,7 +50,7 @@ from pysonar_scanner.configuration.properties import (
     SONAR_SCANNER_ARCH,
     SONAR_SCANNER_OS,
 )
-from pysonar_scanner.configuration.configuration_loader import ConfigurationLoader, SONAR_PROJECT_BASE_DIR
+from pysonar_scanner.configuration.configuration_loader import ConfigurationLoader
 from pysonar_scanner.exceptions import MissingKeyException
 from pysonar_scanner.utils import Arch, Os
 
@@ -66,6 +67,9 @@ class TestConfigurationLoader(pyfakefs.TestCase):
 
     @patch("sys.argv", ["myscript.py", "--token", "myToken", "--sonar-project-key", "myProjectKey"])
     def test_defaults(self, mock_get_os, mock_get_arch):
+        custom_dir = "/my_analysis_directory"
+        self.fs.create_dir(custom_dir)
+        os.chdir(custom_dir)
         configuration = ConfigurationLoader.load()
         expected_configuration = {
             SONAR_TOKEN: "myToken",
@@ -75,7 +79,7 @@ class TestConfigurationLoader(pyfakefs.TestCase):
             SONAR_SCANNER_BOOTSTRAP_START_TIME: configuration[SONAR_SCANNER_BOOTSTRAP_START_TIME],
             SONAR_VERBOSE: False,
             SONAR_SCANNER_SKIP_JRE_PROVISIONING: False,
-            SONAR_PROJECT_BASE_DIR: "/",
+            SONAR_PROJECT_BASE_DIR: "/my_analysis_directory",
             SONAR_SCANNER_CONNECT_TIMEOUT: 5,
             SONAR_SCANNER_SOCKET_TIMEOUT: 60,
             SONAR_SCANNER_RESPONSE_TIMEOUT: 0,
@@ -102,7 +106,7 @@ class TestConfigurationLoader(pyfakefs.TestCase):
         self.assertDictEqual(
             config,
             {
-                SONAR_PROJECT_BASE_DIR: "/",
+                SONAR_PROJECT_BASE_DIR: os.getcwd(),
                 SONAR_SCANNER_OS: Os.LINUX.value,
                 SONAR_SCANNER_ARCH: Arch.X64.value,
             },
@@ -141,7 +145,7 @@ class TestConfigurationLoader(pyfakefs.TestCase):
             SONAR_SCANNER_BOOTSTRAP_START_TIME: configuration[SONAR_SCANNER_BOOTSTRAP_START_TIME],
             SONAR_VERBOSE: False,
             SONAR_SCANNER_SKIP_JRE_PROVISIONING: False,
-            SONAR_PROJECT_BASE_DIR: "/",
+            SONAR_PROJECT_BASE_DIR: os.getcwd(),
             SONAR_SCANNER_CONNECT_TIMEOUT: 5,
             SONAR_SCANNER_SOCKET_TIMEOUT: 60,
             SONAR_SCANNER_RESPONSE_TIMEOUT: 0,
@@ -287,7 +291,7 @@ class TestConfigurationLoader(pyfakefs.TestCase):
             SONAR_SCANNER_BOOTSTRAP_START_TIME: configuration[SONAR_SCANNER_BOOTSTRAP_START_TIME],
             SONAR_VERBOSE: False,
             SONAR_SCANNER_SKIP_JRE_PROVISIONING: False,
-            SONAR_PROJECT_BASE_DIR: "/",
+            SONAR_PROJECT_BASE_DIR: os.getcwd(),
             SONAR_SCANNER_CONNECT_TIMEOUT: 5,
             SONAR_SCANNER_SOCKET_TIMEOUT: 60,
             SONAR_SCANNER_RESPONSE_TIMEOUT: 0,

--- a/tests/test_configuration_loader.py
+++ b/tests/test_configuration_loader.py
@@ -51,11 +51,12 @@ from pysonar_scanner.configuration.properties import (
 )
 from pysonar_scanner.configuration.configuration_loader import ConfigurationLoader, SONAR_PROJECT_BASE_DIR
 from pysonar_scanner.exceptions import MissingKeyException
+from pysonar_scanner.utils import Arch, Os
 
 
 # Mock utils.get_os and utils.get_arch at the module level
-@patch("pysonar_scanner.utils.get_arch", return_value="x64")
-@patch("pysonar_scanner.utils.get_os", return_value="linux")
+@patch("pysonar_scanner.utils.get_arch", return_value=Arch.X64)
+@patch("pysonar_scanner.utils.get_os", return_value=Os.LINUX)
 class TestConfigurationLoader(pyfakefs.TestCase):
     def setUp(self):
         self.maxDiff = None
@@ -80,8 +81,8 @@ class TestConfigurationLoader(pyfakefs.TestCase):
             SONAR_SCANNER_RESPONSE_TIMEOUT: 0,
             SONAR_SCANNER_KEYSTORE_PASSWORD: "changeit",
             SONAR_SCANNER_TRUSTSTORE_PASSWORD: "changeit",
-            SONAR_SCANNER_OS: "linux",
-            SONAR_SCANNER_ARCH: "x64",
+            SONAR_SCANNER_OS: Os.LINUX.value,
+            SONAR_SCANNER_ARCH: Arch.X64.value,
         }
         self.assertDictEqual(configuration, expected_configuration)
 
@@ -102,8 +103,8 @@ class TestConfigurationLoader(pyfakefs.TestCase):
             config,
             {
                 SONAR_PROJECT_BASE_DIR: "/",
-                SONAR_SCANNER_OS: "linux",
-                SONAR_SCANNER_ARCH: "x64",
+                SONAR_SCANNER_OS: Os.LINUX.value,
+                SONAR_SCANNER_ARCH: Arch.X64.value,
             },
         )
 
@@ -146,8 +147,8 @@ class TestConfigurationLoader(pyfakefs.TestCase):
             SONAR_SCANNER_RESPONSE_TIMEOUT: 0,
             SONAR_SCANNER_KEYSTORE_PASSWORD: "changeit",
             SONAR_SCANNER_TRUSTSTORE_PASSWORD: "changeit",
-            SONAR_SCANNER_OS: "linux",
-            SONAR_SCANNER_ARCH: "x64",
+            SONAR_SCANNER_OS: Os.LINUX.value,
+            SONAR_SCANNER_ARCH: Arch.X64.value,
         }
         self.assertDictEqual(configuration, expected_configuration)
 
@@ -194,8 +195,8 @@ class TestConfigurationLoader(pyfakefs.TestCase):
             SONAR_SCANNER_RESPONSE_TIMEOUT: 0,
             SONAR_SCANNER_KEYSTORE_PASSWORD: "changeit",
             SONAR_SCANNER_TRUSTSTORE_PASSWORD: "changeit",
-            SONAR_SCANNER_OS: "linux",
-            SONAR_SCANNER_ARCH: "x64",
+            SONAR_SCANNER_OS: Os.LINUX.value,
+            SONAR_SCANNER_ARCH: Arch.X64.value,
         }
         self.assertDictEqual(configuration, expected_configuration)
 
@@ -243,8 +244,8 @@ class TestConfigurationLoader(pyfakefs.TestCase):
             SONAR_SCANNER_RESPONSE_TIMEOUT: 0,
             SONAR_SCANNER_KEYSTORE_PASSWORD: "changeit",
             SONAR_SCANNER_TRUSTSTORE_PASSWORD: "changeit",
-            SONAR_SCANNER_OS: "linux",
-            SONAR_SCANNER_ARCH: "x64",
+            SONAR_SCANNER_OS: Os.LINUX.value,
+            SONAR_SCANNER_ARCH: Arch.X64.value,
         }
         self.assertDictEqual(configuration, expected_configuration)
 
@@ -292,8 +293,8 @@ class TestConfigurationLoader(pyfakefs.TestCase):
             SONAR_SCANNER_RESPONSE_TIMEOUT: 0,
             SONAR_SCANNER_KEYSTORE_PASSWORD: "changeit",
             SONAR_SCANNER_TRUSTSTORE_PASSWORD: "changeit",
-            SONAR_SCANNER_OS: "linux",
-            SONAR_SCANNER_ARCH: "x64",
+            SONAR_SCANNER_OS: Os.LINUX.value,
+            SONAR_SCANNER_ARCH: Arch.X64.value,
             TOML_PATH: "custom/path",
         }
         self.assertDictEqual(configuration, expected_configuration)
@@ -407,8 +408,8 @@ class TestConfigurationLoader(pyfakefs.TestCase):
 
 
 # If you have test functions outside of classes, use patch as a decorator for each function
-@patch("pysonar_scanner.utils.get_arch", return_value="x64")
-@patch("pysonar_scanner.utils.get_os", return_value="linux")
+@patch("pysonar_scanner.utils.get_arch", return_value=Arch.X64.value)
+@patch("pysonar_scanner.utils.get_os", return_value=Os.LINUX.value)
 def test_standalone_function(mock_get_os, mock_get_arch):
     # ...existing test code...
     pass

--- a/tests/test_jre.py
+++ b/tests/test_jre.py
@@ -41,7 +41,7 @@ import zipfile
 
 
 @patch("pysonar_scanner.utils.get_os", return_value=Os.LINUX)
-@patch("pysonar_scanner.utils.get_arch", return_value=Arch.AARCH64)
+@patch("pysonar_scanner.utils.get_arch", return_value=Arch.X64)
 class TestJREProvisioner(pyfakefs.TestCase):
     def setUp(self):
         self.setUpPyfakefs(allow_root_user=False)
@@ -115,7 +115,7 @@ class TestJREProvisioner(pyfakefs.TestCase):
 
     def test_if_patching_worked(self, get_os_mock, get_arch_mock):
         self.assertEqual(utils.get_os(), Os.LINUX)
-        self.assertEqual(utils.get_arch(), Arch.AARCH64)
+        self.assertEqual(utils.get_arch(), Arch.X64)
 
     def test_successfully_downloading_jre(self, get_os_mock, get_arch_mock):
         class JRETestCase(TypedDict):

--- a/tests/test_scannerengine.py
+++ b/tests/test_scannerengine.py
@@ -147,6 +147,8 @@ class TestScannerEngineWithFake(pyfakefs.TestCase):
         config = {
             "sonar.token": "myToken",
             "sonar.projectKey": "myProjectKey",
+            "sonar.scanner.os": "linux",
+            "sonar.scanner.arch": "x64",
         }
 
         expected_std_in = json.dumps(
@@ -154,6 +156,8 @@ class TestScannerEngineWithFake(pyfakefs.TestCase):
                 "scannerProperties": [
                     {"key": "sonar.token", "value": "myToken"},
                     {"key": "sonar.projectKey", "value": "myProjectKey"},
+                    {"key": "sonar.scanner.os", "value": "linux"},
+                    {"key": "sonar.scanner.arch", "value": "x64"},
                 ]
             }
         )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -23,7 +23,7 @@ import unittest
 import unittest.mock
 import pyfakefs.fake_filesystem_unittest as pyfakefs
 
-from pysonar_scanner.utils import get_arch, get_os, remove_trailing_slash, calculate_checksum
+from pysonar_scanner.utils import Arch, Os, get_arch, get_os, remove_trailing_slash, calculate_checksum
 
 
 class TestUtils(unittest.TestCase):
@@ -35,10 +35,10 @@ class TestUtils(unittest.TestCase):
 
     def test_get_os(self):
         with self.subTest("os=Windows"), unittest.mock.patch("platform.system", return_value="Windows"):
-            self.assertEqual(get_os(), "windows")
+            self.assertEqual(get_os(), Os.WINDOWS)
 
         with self.subTest("os=Darwin"), unittest.mock.patch("platform.system", return_value="Darwin"):
-            self.assertEqual(get_os(), "mac")
+            self.assertEqual(get_os(), Os.MACOS)
 
     def test_get_arch(self):
         x64_machine_strs = ["amd64", "AmD64", "x86_64", "X86_64"]
@@ -46,13 +46,13 @@ class TestUtils(unittest.TestCase):
             with self.subTest("amd64", machine_str=machine_str), unittest.mock.patch(
                 "platform.machine", return_value=machine_str
             ):
-                self.assertEqual(get_arch(), "x64")
+                self.assertEqual(get_arch(), Arch.X64)
         arm_machine_strs = ["arm64", "ARm64"]
         for machine_str in arm_machine_strs:
             with self.subTest("arm", machine_str=machine_str), unittest.mock.patch(
                 "platform.machine", return_value=machine_str
             ):
-                self.assertEqual(get_arch(), "aarch64")
+                self.assertEqual(get_arch(), Arch.AARCH64)
 
 
 class TestAlpineDetection(unittest.TestCase):
@@ -99,7 +99,7 @@ class TestAlpineDetection(unittest.TestCase):
                 ):
                     assert patcher.fs is not None
                     patcher.fs.create_file(os_release_location, contents=alpine_text)
-                    self.assertEqual(get_os(), "alpine")
+                    self.assertEqual(get_os(), Os.ALPINE)
 
     def test_os_release_for_generic_linux(self):
         for os_release_location in self.os_release_locations:
@@ -110,7 +110,7 @@ class TestAlpineDetection(unittest.TestCase):
             ):
                 assert patcher.fs is not None
                 patcher.fs.create_file(os_release_location, contents=self.ubuntu_text)
-                self.assertEqual(get_os(), "linux")
+                self.assertEqual(get_os(), Os.LINUX)
 
     def test_os_release_does_not_exist(self):
         with (
@@ -120,7 +120,7 @@ class TestAlpineDetection(unittest.TestCase):
         ):
             self.assertFalse(pathlib.Path("/etc/os-release").exists())
             self.assertFalse(pathlib.Path("/usr/lib/os-release").exists())
-            self.assertEqual(get_os(), "linux")
+            self.assertEqual(get_os(), Os.LINUX)
 
 
 class TestCalculateChecksum(unittest.TestCase):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -23,7 +23,7 @@ import unittest
 import unittest.mock
 import pyfakefs.fake_filesystem_unittest as pyfakefs
 
-from pysonar_scanner.utils import Arch, Os, get_arch, get_os, remove_trailing_slash, calculate_checksum
+from pysonar_scanner.utils import get_arch, get_os, remove_trailing_slash, calculate_checksum
 
 
 class TestUtils(unittest.TestCase):
@@ -35,10 +35,10 @@ class TestUtils(unittest.TestCase):
 
     def test_get_os(self):
         with self.subTest("os=Windows"), unittest.mock.patch("platform.system", return_value="Windows"):
-            self.assertEqual(get_os(), Os.WINDOWS)
+            self.assertEqual(get_os(), "windows")
 
         with self.subTest("os=Darwin"), unittest.mock.patch("platform.system", return_value="Darwin"):
-            self.assertEqual(get_os(), Os.MACOS)
+            self.assertEqual(get_os(), "mac")
 
     def test_get_arch(self):
         x64_machine_strs = ["amd64", "AmD64", "x86_64", "X86_64"]
@@ -46,13 +46,13 @@ class TestUtils(unittest.TestCase):
             with self.subTest("amd64", machine_str=machine_str), unittest.mock.patch(
                 "platform.machine", return_value=machine_str
             ):
-                self.assertEqual(get_arch(), Arch.X64)
+                self.assertEqual(get_arch(), "x64")
         arm_machine_strs = ["arm64", "ARm64"]
         for machine_str in arm_machine_strs:
             with self.subTest("arm", machine_str=machine_str), unittest.mock.patch(
                 "platform.machine", return_value=machine_str
             ):
-                self.assertEqual(get_arch(), Arch.AARCH64)
+                self.assertEqual(get_arch(), "aarch64")
 
 
 class TestAlpineDetection(unittest.TestCase):
@@ -99,7 +99,7 @@ class TestAlpineDetection(unittest.TestCase):
                 ):
                     assert patcher.fs is not None
                     patcher.fs.create_file(os_release_location, contents=alpine_text)
-                    self.assertEqual(get_os(), Os.ALPINE)
+                    self.assertEqual(get_os(), "alpine")
 
     def test_os_release_for_generic_linux(self):
         for os_release_location in self.os_release_locations:
@@ -110,7 +110,7 @@ class TestAlpineDetection(unittest.TestCase):
             ):
                 assert patcher.fs is not None
                 patcher.fs.create_file(os_release_location, contents=self.ubuntu_text)
-                self.assertEqual(get_os(), Os.LINUX)
+                self.assertEqual(get_os(), "linux")
 
     def test_os_release_does_not_exist(self):
         with (
@@ -120,7 +120,7 @@ class TestAlpineDetection(unittest.TestCase):
         ):
             self.assertFalse(pathlib.Path("/etc/os-release").exists())
             self.assertFalse(pathlib.Path("/usr/lib/os-release").exists())
-            self.assertEqual(get_os(), Os.LINUX)
+            self.assertEqual(get_os(), "linux")
 
 
 class TestCalculateChecksum(unittest.TestCase):


### PR DESCRIPTION
[SCANPY-145](https://sonarsource.atlassian.net/browse/SCANPY-145)

Due to the fact that our config is string based, I initially removed the `Os` and `Arch` enums. Seeing that this led to relying a bit too much on string literals, I added the second commit to keep these classes, simplifying tests in particular.
It may be a bit overkill, so I left it as a separate commit in case you'd like to challenge the approach.

[SCANPY-145]: https://sonarsource.atlassian.net/browse/SCANPY-145?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ