### PR TITLE
SCANPY-120 Use the new region URLs

### DIFF
--- a/src/pysonar_scanner/exceptions.py
+++ b/src/pysonar_scanner/exceptions.py
@@ -31,6 +31,10 @@ class SQTooOldException(Exception):
     pass
 
 
+class InconsistentConfiguration(Exception):
+    pass
+
+
 class ChecksumException(Exception):
     pass
 


### PR DESCRIPTION
[SCANPY-120](https://sonarsource.atlassian.net/browse/SCANPY-120)

Used the following implementation as a reference:
https://github.com/SonarSource/sonar-scanner-java-library/blob/7556a8f71999ad457ac77ec2416b1d837539b478/lib/src/main/java/org/sonarsource/scanner/lib/internal/endpoint/ScannerEndpointResolver.java#L37

Tests:
https://github.com/SonarSource/sonar-scanner-java-library/blob/7556a8f71999ad457ac77ec2416b1d837539b478/lib/src/test/java/org/sonarsource/scanner/lib/internal/endpoint/ScannerEndpointResolverTest.java#L139

[SCANPY-120]: https://sonarsource.atlassian.net/browse/SCANPY-120?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ