### PR TITLE
SCANPY-160 add mypy to the ci

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -157,7 +157,9 @@ analysis_linux_task:
   alias: analysis
   name: "NEXT Analysis"
   analysis_script:
+    - poetry install
     - poetry run pytest --cov-report=xml:coverage.xml --cov-config=pyproject.toml --cov=src --cov-branch tests
+    - poetry run mypy src/ > mypy-report.txt || true # mypy exits with 1 if there are errors
     - uv venv
     - source .venv/bin/activate
     - uv pip install pysonar-scanner

--- a/poetry.lock
+++ b/poetry.lock
@@ -1024,6 +1024,26 @@ url = "https://repox.jfrog.io/artifactory/api/pypi/sonarsource-pypi/simple"
 reference = "jfrog-server"
 
 [[package]]
+name = "types-requests"
+version = "2.32.0.20250328"
+description = "Typing stubs for requests"
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "types_requests-2.32.0.20250328-py3-none-any.whl", hash = "sha256:72ff80f84b15eb3aa7a8e2625fffb6a93f2ad5a0c20215fc1dcfa61117bcb2a2"},
+    {file = "types_requests-2.32.0.20250328.tar.gz", hash = "sha256:c9e67228ea103bd811c96984fac36ed2ae8da87a36a633964a21f199d60baf32"},
+]
+
+[package.dependencies]
+urllib3 = ">=2"
+
+[package.source]
+type = "legacy"
+url = "https://repox.jfrog.io/artifactory/api/pypi/sonarsource-pypi/simple"
+reference = "jfrog-server"
+
+[[package]]
 name = "typing-extensions"
 version = "4.12.2"
 description = "Backported and Experimental Type Hints for Python 3.8+"
@@ -1046,7 +1066,7 @@ version = "2.3.0"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
 python-versions = ">=3.9"
-groups = ["main"]
+groups = ["main", "dev"]
 files = [
     {file = "urllib3-2.3.0-py3-none-any.whl", hash = "sha256:1cee9ad369867bfdbbb48b7dd50374c0967a0bb7710050facf0dd6911440e3df"},
     {file = "urllib3-2.3.0.tar.gz", hash = "sha256:f8c5449b3cf0861679ce7e0503c7b44b5ec981bec0d1d3795a07f1ba96f0204d"},
@@ -1066,4 +1086,4 @@ reference = "jfrog-server"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9"
-content-hash = "e7c9b8fb35c2915f707b18ee5a1f14bd544b344d2219a46afb7057d8fb879792"
+content-hash = "e9ab97d1ae5c80511854ce753d1fb723e2330acefb653e4017a2264f7161d9cd"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ pytest-cov = '6.0.0'
 pytest-subtests = "^0.14.1"
 pytest-docker = "^3.2.0"
 debugpy = "^1.8.13"
+types-requests = "^2.32.0.20250328"
 
 [[tool.poetry.packages]]
 from = 'src'

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,6 +3,7 @@ sonar.projectName=Python Scanner
 sonar.projectVersion=1.0.0
 sonar.python.version=3.9,3.10,3.11,3.12,3.13
 sonar.python.coverage.reportPaths=coverage.xml
+sonar.python.mypy.reportPaths=mypy-report.txt
 sonar.analysisCache.enabled=true
 sonar.sources=src
 sonar.tests=tests

--- a/src/pysonar_scanner/__main__.py
+++ b/src/pysonar_scanner/__main__.py
@@ -18,6 +18,7 @@
 # Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
 
+from typing import Any
 from pysonar_scanner import app_logging
 from pysonar_scanner import cache
 from pysonar_scanner.api import get_base_urls, SonarQubeApi, BaseUrls, MIN_SUPPORTED_SQ_VERSION
@@ -58,7 +59,7 @@ def set_logging_options(config):
     app_logging.configure_logging_level(verbose=config.get(SONAR_VERBOSE, False))
 
 
-def build_api(config: dict[str, any]) -> SonarQubeApi:
+def build_api(config: dict[str, Any]) -> SonarQubeApi:
     token = configuration_loader.get_token(config)
     base_urls = get_base_urls(config)
     return SonarQubeApi(base_urls, token)
@@ -90,7 +91,7 @@ def create_scanner_engine(api, cache_manager, config):
     return scanner
 
 
-def create_jre(api, cache, config: dict[str, any]) -> JREResolvedPath:
+def create_jre(api, cache, config: dict[str, Any]) -> JREResolvedPath:
     jre_provisioner = JREProvisioner(api, cache, config[SONAR_SCANNER_OS], config[SONAR_SCANNER_ARCH])
     jre_resolver = JREResolver(JREResolverConfiguration.from_dict(config), jre_provisioner)
     return jre_resolver.resolve_jre()

--- a/src/pysonar_scanner/api.py
+++ b/src/pysonar_scanner/api.py
@@ -19,7 +19,7 @@
 #
 import typing
 from dataclasses import dataclass
-from typing import Any, Optional, TypedDict
+from typing import Any, Optional
 
 import requests
 import requests.auth
@@ -112,24 +112,26 @@ class JRE:
             raise MissingKeyException(f"Missing key in dictionary {dict}") from e
 
 
-ApiConfiguration = TypedDict(
-    "ApiConfiguration",
-    {SONAR_HOST_URL: str, SONAR_SCANNER_SONARCLOUD_URL: str, SONAR_SCANNER_API_BASE_URL: str, SONAR_REGION: str},
-)
+@dataclass(frozen=True)
+class ApiConfiguration:
+    sonar_host_url: str
+    sonar_scanner_sonarcloud_url: str
+    sonar_scanner_api_base_url: str
+    sonar_region: str
 
 
 def to_api_configuration(config_dict: dict[Key, Any]) -> ApiConfiguration:
-    return {
-        SONAR_HOST_URL: config_dict.get(SONAR_HOST_URL, ""),
-        SONAR_SCANNER_SONARCLOUD_URL: config_dict.get(SONAR_SCANNER_SONARCLOUD_URL, ""),
-        SONAR_SCANNER_API_BASE_URL: config_dict.get(SONAR_SCANNER_API_BASE_URL, ""),
-        SONAR_REGION: config_dict.get(SONAR_REGION, ""),
-    }
+    return ApiConfiguration(
+        sonar_host_url=config_dict.get(SONAR_HOST_URL, ""),
+        sonar_scanner_sonarcloud_url=config_dict.get(SONAR_SCANNER_SONARCLOUD_URL, ""),
+        sonar_scanner_api_base_url=config_dict.get(SONAR_SCANNER_API_BASE_URL, ""),
+        sonar_region=config_dict.get(SONAR_REGION, ""),
+    )
 
 
 def get_base_urls(config_dict: dict[Key, Any]) -> BaseUrls:
     def is_sq_cloud_url(api_config: ApiConfiguration, sonar_host_url: str) -> bool:
-        sq_cloud_url = api_config[SONAR_SCANNER_SONARCLOUD_URL] or GLOBAL_SONARCLOUD_URL
+        sq_cloud_url = api_config.sonar_scanner_sonarcloud_url or GLOBAL_SONARCLOUD_URL
         return remove_trailing_slash(sonar_host_url) in [remove_trailing_slash(sq_cloud_url), US_SONARCLOUD_URL]
 
     def is_blank(str) -> bool:
@@ -137,8 +139,8 @@ def get_base_urls(config_dict: dict[Key, Any]) -> BaseUrls:
 
     api_config: ApiConfiguration = to_api_configuration(config_dict)
 
-    sonar_host_url = remove_trailing_slash(api_config[SONAR_HOST_URL])
-    region = api_config[SONAR_REGION]
+    sonar_host_url = remove_trailing_slash(api_config.sonar_host_url)
+    region = api_config.sonar_region
     if region and region != "us":
         raise InconsistentConfiguration(
             f"Invalid region '{region}'. Valid regions are: 'us'. "
@@ -152,11 +154,11 @@ def get_base_urls(config_dict: dict[Key, Any]) -> BaseUrls:
     if is_blank(sonar_host_url) or is_sq_cloud_url(api_config, sonar_host_url):
         default_url = US_SONARCLOUD_URL if region == "us" else GLOBAL_SONARCLOUD_URL
         default_api_base_url = "https://api.sonarqube.us" if region == "us" else "https://api.sonarcloud.io"
-        sonar_host_url = api_config[SONAR_SCANNER_SONARCLOUD_URL] or default_url
-        api_base_url = api_config[SONAR_SCANNER_API_BASE_URL] or default_api_base_url
+        sonar_host_url = api_config.sonar_scanner_sonarcloud_url or default_url
+        api_base_url = api_config.sonar_scanner_api_base_url or default_api_base_url
         return BaseUrls(base_url=sonar_host_url, api_base_url=api_base_url, is_sonar_qube_cloud=True)
     else:
-        api_base_url = api_config[SONAR_SCANNER_API_BASE_URL] or f"{sonar_host_url}/api/v2"
+        api_base_url = api_config.sonar_scanner_api_base_url or f"{sonar_host_url}/api/v2"
         return BaseUrls(base_url=sonar_host_url, api_base_url=api_base_url, is_sonar_qube_cloud=False)
 
 

--- a/src/pysonar_scanner/api.py
+++ b/src/pysonar_scanner/api.py
@@ -19,7 +19,7 @@
 #
 import typing
 from dataclasses import dataclass
-from typing import Optional, TypedDict
+from typing import Any, Optional, TypedDict
 
 import requests
 import requests.auth
@@ -118,7 +118,7 @@ ApiConfiguration = TypedDict(
 )
 
 
-def to_api_configuration(config_dict: dict[Key, any]) -> ApiConfiguration:
+def to_api_configuration(config_dict: dict[Key, Any]) -> ApiConfiguration:
     return {
         SONAR_HOST_URL: config_dict.get(SONAR_HOST_URL, ""),
         SONAR_SCANNER_SONARCLOUD_URL: config_dict.get(SONAR_SCANNER_SONARCLOUD_URL, ""),
@@ -127,7 +127,7 @@ def to_api_configuration(config_dict: dict[Key, any]) -> ApiConfiguration:
     }
 
 
-def get_base_urls(config_dict: dict[Key, any]) -> BaseUrls:
+def get_base_urls(config_dict: dict[Key, Any]) -> BaseUrls:
     def is_sq_cloud_url(api_config: ApiConfiguration, sonar_host_url: str) -> bool:
         sq_cloud_url = api_config[SONAR_SCANNER_SONARCLOUD_URL] or GLOBAL_SONARCLOUD_URL
         return remove_trailing_slash(sonar_host_url) in [remove_trailing_slash(sq_cloud_url), US_SONARCLOUD_URL]

--- a/src/pysonar_scanner/configuration/cli.py
+++ b/src/pysonar_scanner/configuration/cli.py
@@ -18,6 +18,7 @@
 # Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
 import argparse
+from typing import Any
 
 from pysonar_scanner.configuration import properties
 from pysonar_scanner.exceptions import UnexpectedCliArgument
@@ -26,7 +27,7 @@ from pysonar_scanner.exceptions import UnexpectedCliArgument
 class CliConfigurationLoader:
 
     @classmethod
-    def load(cls) -> dict[str, any]:
+    def load(cls) -> dict[str, Any]:
         args, unknown_args = cls.__parse_cli_args()
         config = {}
         for prop in properties.PROPERTIES:

--- a/src/pysonar_scanner/configuration/configuration_loader.py
+++ b/src/pysonar_scanner/configuration/configuration_loader.py
@@ -18,6 +18,7 @@
 # Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
 from pathlib import Path
+from typing import Any
 
 from pysonar_scanner.configuration.cli import CliConfigurationLoader
 from pysonar_scanner.configuration.pyproject_toml import TomlConfigurationLoader
@@ -28,13 +29,13 @@ from pysonar_scanner.configuration import sonar_project_properties, environment_
 from pysonar_scanner.exceptions import MissingKeyException
 
 
-def get_static_default_properties() -> dict[Key, any]:
+def get_static_default_properties() -> dict[Key, Any]:
     return {prop.name: prop.default_value for prop in PROPERTIES if prop.default_value is not None}
 
 
 class ConfigurationLoader:
     @staticmethod
-    def load() -> dict[Key, any]:
+    def load() -> dict[Key, Any]:
         # each property loader is required to return NO default values.
         # E.g. if no property has been set, an empty dict must be returned.
         # Default values should be set through the get_static_default_properties() method
@@ -57,7 +58,7 @@ class ConfigurationLoader:
         return resolved_properties
 
 
-def get_token(config: dict[Key, any]) -> str:
+def get_token(config: dict[Key, Any]) -> str:
     if SONAR_TOKEN not in config:
         raise MissingKeyException(f'Missing property "{SONAR_TOKEN}"')
     return config[SONAR_TOKEN]

--- a/src/pysonar_scanner/configuration/dynamic_defaults_loader.py
+++ b/src/pysonar_scanner/configuration/dynamic_defaults_loader.py
@@ -18,13 +18,13 @@
 # Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
 import os
-from typing import Dict
+from typing import Any, Dict
 
 from pysonar_scanner.configuration.properties import Key, SONAR_SCANNER_OS, SONAR_SCANNER_ARCH, SONAR_PROJECT_BASE_DIR
 from pysonar_scanner import utils
 
 
-def load() -> Dict[Key, any]:
+def load() -> Dict[Key, Any]:
     """
     Load dynamically computed default properties
     """

--- a/src/pysonar_scanner/configuration/properties.py
+++ b/src/pysonar_scanner/configuration/properties.py
@@ -20,7 +20,7 @@
 import time
 import argparse
 from dataclasses import dataclass
-from typing import Callable, Optional
+from typing import Any, Callable, Optional
 
 Key = str
 
@@ -101,10 +101,10 @@ class Property:
     name: Key
     """name in the format of `sonar.scanner.appVersion`"""
 
-    default_value: Optional[any]
+    default_value: Optional[Any]
     """default value for the property; if None, no default value is set"""
 
-    cli_getter: Optional[Callable[[argparse.Namespace], any]] = None
+    cli_getter: Optional[Callable[[argparse.Namespace], Any]] = None
     """function to get the value from the CLI arguments namespace. If None, the property is not settable via CLI"""
 
     def python_name(self) -> str:

--- a/src/pysonar_scanner/configuration/pyproject_toml.py
+++ b/src/pysonar_scanner/configuration/pyproject_toml.py
@@ -18,7 +18,7 @@
 # Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
 from pathlib import Path
-from typing import Dict
+from typing import Any, Dict
 import os
 import tomli
 
@@ -84,7 +84,7 @@ class TomlConfigurationLoader:
         return project_properties
 
     @staticmethod
-    def __flatten_config_dict(config: dict[str, any], prefix: str) -> dict[str, any]:
+    def __flatten_config_dict(config: dict[str, Any], prefix: str) -> dict[str, Any]:
         """Flatten nested dictionaries into dot notation keys"""
         result = {}
         for key, value in config.items():

--- a/src/pysonar_scanner/jre.py
+++ b/src/pysonar_scanner/jre.py
@@ -54,7 +54,9 @@ class JREResolvedPath:
 
 
 class JREProvisioner:
-    def __init__(self, api: SonarQubeApi, cache: Cache, sonar_scanner_os: str, sonar_scanner_arch: str):
+    def __init__(
+        self, api: SonarQubeApi, cache: Cache, sonar_scanner_os: utils.OsStr, sonar_scanner_arch: utils.ArchStr
+    ):
         self.api = api
         self.cache = cache
         self.sonar_scanner_os = sonar_scanner_os

--- a/src/pysonar_scanner/jre.py
+++ b/src/pysonar_scanner/jre.py
@@ -22,7 +22,7 @@ import shutil
 import tarfile
 import zipfile
 from dataclasses import dataclass
-from typing import Optional
+from typing import Any, Optional
 
 from pysonar_scanner import utils
 from pysonar_scanner.api import JRE, SonarQubeApi
@@ -139,7 +139,7 @@ class JREResolverConfiguration:
     sonar_scanner_os: Optional[str]
 
     @staticmethod
-    def from_dict(config_dict: dict[Key, any]) -> "JREResolverConfiguration":
+    def from_dict(config_dict: dict[Key, Any]) -> "JREResolverConfiguration":
         return JREResolverConfiguration(
             sonar_scanner_java_exe_path=config_dict.get(SONAR_SCANNER_JAVA_EXE_PATH, None),
             sonar_scanner_skip_jre_provisioning=config_dict.get(SONAR_SCANNER_SKIP_JRE_PROVISIONING, False),

--- a/src/pysonar_scanner/scannerengine.py
+++ b/src/pysonar_scanner/scannerengine.py
@@ -144,10 +144,10 @@ class ScannerEngine:
         return CmdExecutor(cmd, properties_str).execute()
 
     def __build_command(self, jre_path: JREResolvedPath, scanner_engine_path: pathlib.Path) -> list[str]:
-        cmd = []
-        cmd.append(jre_path.path)
+        cmd: list[str] = []
+        cmd.append(str(jre_path.path))
         cmd.append("-jar")
-        cmd.append(scanner_engine_path)
+        cmd.append(str(scanner_engine_path))
         return cmd
 
     def __config_to_json(self, config: dict[str, Any]) -> str:

--- a/src/pysonar_scanner/scannerengine.py
+++ b/src/pysonar_scanner/scannerengine.py
@@ -23,7 +23,7 @@ import pathlib
 from dataclasses import dataclass
 from subprocess import Popen, PIPE
 from threading import Thread
-from typing import IO, Callable, Optional
+from typing import IO, Any, Callable, Optional
 
 from pysonar_scanner.api import SonarQubeApi
 from pysonar_scanner.cache import Cache, CacheFile
@@ -138,7 +138,7 @@ class ScannerEngine:
         self.jre_path = jre_path
         self.scanner_engine_path = scanner_engine_path
 
-    def run(self, config: dict[str, any]):
+    def run(self, config: dict[str, Any]):
         cmd = self.__build_command(self.jre_path, self.scanner_engine_path)
         properties_str = self.__config_to_json(config)
         return CmdExecutor(cmd, properties_str).execute()
@@ -150,6 +150,6 @@ class ScannerEngine:
         cmd.append(scanner_engine_path)
         return cmd
 
-    def __config_to_json(self, config: dict[str, any]) -> str:
+    def __config_to_json(self, config: dict[str, Any]) -> str:
         scanner_properties = [{"key": k, "value": v} for k, v in config.items()]
         return json.dumps({"scannerProperties": scanner_properties})

--- a/src/pysonar_scanner/utils.py
+++ b/src/pysonar_scanner/utils.py
@@ -39,11 +39,11 @@ def calculate_checksum(filehandle: typing.BinaryIO) -> str:
 
 
 class Os(Enum):
-    WINDOWS: OsStr = "windows"
-    LINUX: OsStr = "linux"
-    MACOS: OsStr = "mac"
-    ALPINE: OsStr = "alpine"
-    OTHER: OsStr = "other"
+    WINDOWS = "windows"
+    LINUX = "linux"
+    MACOS = "mac"
+    ALPINE = "alpine"
+    OTHER = "other"
 
 
 def get_os() -> Os:
@@ -73,9 +73,9 @@ def get_os() -> Os:
 
 
 class Arch(Enum):
-    X64: ArchStr = "x64"
-    AARCH64: ArchStr = "aarch64"
-    OTHER: ArchStr = "other"
+    X64 = "x64"
+    AARCH64 = "aarch64"
+    OTHER = "other"
 
 
 def get_arch() -> Arch:

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -30,7 +30,7 @@ from pysonar_scanner.configuration.properties import (
     SONAR_SCANNER_API_BASE_URL,
     SONAR_SCANNER_SONARCLOUD_URL,
 )
-from pysonar_scanner.api import SQVersion
+from pysonar_scanner.api import SQVersion, ApiConfiguration
 from pysonar_scanner.exceptions import InconsistentConfiguration
 from tests.unit import sq_api_utils
 from tests.unit.sq_api_utils import sq_api_mocker
@@ -433,19 +433,25 @@ class TestSonarQubeApi(unittest.TestCase):
 
     def test_to_api_configuration(self):
         with self.subTest("Missing keys"):
-            expected = {
-                SONAR_HOST_URL: "",
-                SONAR_SCANNER_SONARCLOUD_URL: "",
-                SONAR_SCANNER_API_BASE_URL: "",
-                SONAR_REGION: "",
-            }
+            expected = ApiConfiguration(
+                sonar_host_url="",
+                sonar_scanner_sonarcloud_url="",
+                sonar_scanner_api_base_url="",
+                sonar_region="",
+            )
             self.assertEqual(expected, api.to_api_configuration({}))
 
         with self.subTest("All keys"):
-            expected = {
+            input_config = {
                 SONAR_HOST_URL: "https://sonarcloud.io",
                 SONAR_SCANNER_SONARCLOUD_URL: "https://sonarcloud.io",
                 SONAR_SCANNER_API_BASE_URL: "https://api.sonarcloud.io",
                 SONAR_REGION: "us",
             }
-            self.assertEqual(expected, api.to_api_configuration(expected))
+            expected = ApiConfiguration(
+                sonar_host_url="https://sonarcloud.io",
+                sonar_scanner_sonarcloud_url="https://sonarcloud.io",
+                sonar_scanner_api_base_url="https://api.sonarcloud.io",
+                sonar_region="us",
+            )
+            self.assertEqual(expected, api.to_api_configuration(input_config))

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -17,7 +17,7 @@
 # along with this program; if not, write to the Free Software Foundation,
 # Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
-from typing import TypedDict
+from typing import Any, TypedDict
 
 import io
 
@@ -73,7 +73,7 @@ class TestApi(unittest.TestCase):
     def test_get_base_urls(self):
         class TestCaseDict(TypedDict):
             name: str
-            config: dict[Key, any]
+            config: dict[Key, Any]
             expected: BaseUrls
 
         cases: list[TestCaseDict] = [
@@ -204,7 +204,7 @@ class TestApi(unittest.TestCase):
     def test_inconsistent_urls_raises_exception(self):
         class TestCaseDict(TypedDict):
             name: str
-            config: dict[Key, any]
+            config: dict[Key, Any]
             expected: str
 
         cases: list[TestCaseDict] = [

--- a/tests/unit/test_scannerengine.py
+++ b/tests/unit/test_scannerengine.py
@@ -152,14 +152,15 @@ class TestScannerEngineWithFake(pyfakefs.TestCase):
                 ]
             }
         )
+        java_path = pathlib.Path("jre/bin/java")
         jre_resolve_path_mock = Mock()
-        jre_resolve_path_mock.path = pathlib.Path("jre/bin/java")
+        jre_resolve_path_mock.path = java_path
         scanner_engine_mock = pathlib.Path("/test/scanner-engine.jar")
 
         scannerengine.ScannerEngine(jre_resolve_path_mock, scanner_engine_mock).run(config)
 
         execute_mock.assert_called_once_with(
-            [pathlib.Path("jre/bin/java"), "-jar", pathlib.Path("/test/scanner-engine.jar")], expected_std_in
+            [str(java_path), "-jar", str(pathlib.Path("/test/scanner-engine.jar"))], expected_std_in
         )
 
 


### PR DESCRIPTION
[SCANPY-160](https://sonarsource.atlassian.net/browse/SCANPY-160)

Unfortunately, SQ:Server doesn't show the new mypy issues because the code wasn't changed. They do however show up in the branch analysis. See [here](https://next.sonarqube.com/sonarqube/dashboard?id=SonarSource_sonar-scanner-python&branch=branch-sz-add-mypy&codeScope=overall) for the analysis result of the `branch-sz-add-mypy` branch.

I've accepted one mypy issue which is about missing stubs for the `jproperties` library (see [here](https://next.sonarqube.com/sonarqube/project/issues?branch=branch-sz-add-mypy&issueStatuses=ACCEPTED&open=330354c6-adf9-4482-9554-6a77da40f389&id=SonarSource_sonar-scanner-python))

[SCANPY-160]: https://sonarsource.atlassian.net/browse/SCANPY-160?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ