### PR TITLE
SCANPY-165 Prepare for next development iteration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ keywords = ['sonar', 'sonarqube', 'sonarcloud', 'cleancode']
 license = 'LGPL-3.0-only'
 name = 'pysonar'
 readme = 'README.md'
-version = "1.0.0"
+version = "1.0.1"
 dynamic = ["dependencies"]
 
 [project.urls]


### PR DESCRIPTION
Bumping to `1.01` as we need to perform a new release with the updated README so that the package description on PyPI is not misleading.