### PR TITLE
Ensure exit code is properly reported to the shell

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ from = 'src'
 include = 'pysonar_scanner'
 
 [tool.poetry.scripts]
-pysonar = 'pysonar_scanner.__main__:scan'
+pysonar = 'pysonar_scanner.__main__:entry_point'
 
 [[tool.poetry.source]]
 name = 'jfrog-server'

--- a/src/pysonar_scanner/__main__.py
+++ b/src/pysonar_scanner/__main__.py
@@ -47,6 +47,9 @@ def scan():
     except Exception as e:
         return exceptions.log_error(e)
 
+def entry_point():
+    # Ensure the exit code is properly returned to the shell
+    exit(scan())
 
 def do_scan():
     app_logging.setup()


### PR DESCRIPTION
Problem description:

When ANY failure happens within the SonarQube operation, the error status is NEVER reported to the calling context / shell. This means that the `pysonar-scanner` CLI tool always returns a successful result. This makes it impossible to detect failures at runtime.

Solution:
Ensure the return code from the `scan()` method is properly reported to the shell.
