### PR TITLE
SCANPY-181 Only use the the filter parameter of tarfile.extractall if supported

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -194,10 +194,14 @@ analysis_linux_task:
 qa_task:
   alias: qa
   matrix:
-    - name: "Test Python 3.9"
+    - name: "Test Python 3.9.18"
       eks_container:
         docker_arguments:
           PYTHON_VERSION: 3.9.18
+    - name: "Test Python 3.9.6"
+      eks_container:
+        docker_arguments:
+          PYTHON_VERSION: 3.9.6
     - name: "Test Python 3.10"
       eks_container:
         docker_arguments:

--- a/src/pysonar_scanner/jre.py
+++ b/src/pysonar_scanner/jre.py
@@ -135,8 +135,7 @@ class JREProvisioner:
             with zipfile.ZipFile(file_path, "r") as zip_ref:
                 zip_ref.extractall(unzip_dir)
         elif file_path.suffix in [".gz", ".tgz"]:
-            with tarfile.open(file_path, "r:gz") as tar_ref:
-                tar_ref.extractall(unzip_dir, filter="data")
+            utils.extract_tar(file_path, unzip_dir)
         else:
             raise UnsupportedArchiveFormat(
                 f"Received JRE is packaged as an unsupported archive format: {file_path.suffix}"

--- a/src/pysonar_scanner/utils.py
+++ b/src/pysonar_scanner/utils.py
@@ -20,6 +20,8 @@
 import hashlib
 import pathlib
 import platform
+import sys
+import tarfile
 import typing
 from enum import Enum
 
@@ -89,3 +91,11 @@ def get_arch() -> Arch:
 
 def filter_none_values(dictionary: dict) -> dict:
     return {k: v for k, v in dictionary.items() if v is not None}
+
+
+def extract_tar(path: pathlib.Path, target_dir: pathlib.Path):
+    with tarfile.open(path, "r:gz") as tar_ref:
+        if sys.version_info >= (3, 12):
+            tar_ref.extractall(target_dir, filter="data")
+        else:
+            tar_ref.extractall(target_dir)


### PR DESCRIPTION
[SCANPY-181](https://sonarsource.atlassian.net/browse/SCANPY-181)

So far, pysonar has used the `filter` parameter of `tarfile.extractall(...)`, which was introduced in Python 3.12. However, the parameter was backported to 3.9.17, 3.10.12, 3.11.4, which all released on 06.06.2023. Because we used up to date Python versions, which had the backport, in our ITs, they didn't fail and we didn't notice.

[SCANPY-181]: https://sonarsource.atlassian.net/browse/SCANPY-181?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ