### PR TITLE
BUILD-8875: Migrate to standardized GitHub runner names

### DIFF
--- a/.github/workflows/PullRequestClosed.yml
+++ b/.github/workflows/PullRequestClosed.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   PullRequestMerged_job:
     name: Pull Request Merged
-    runs-on: ubuntu-latest-large
+    runs-on: github-ubuntu-latest-s
     permissions:
       id-token: write
       pull-requests: read

--- a/.github/workflows/PullRequestCreated.yml
+++ b/.github/workflows/PullRequestCreated.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   PullRequestCreated_job:
     name: Pull Request Created
-    runs-on: ubuntu-latest-large
+    runs-on: github-ubuntu-latest-s
     permissions:
       id-token: write
     # For external PR, ticket should be created manually

--- a/.github/workflows/RequestReview.yml
+++ b/.github/workflows/RequestReview.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   RequestReview_job:
     name: Request review
-    runs-on: ubuntu-latest-large
+    runs-on: github-ubuntu-latest-s
     permissions:
       id-token: write
     # For external PR, ticket should be moved manually

--- a/.github/workflows/SubmitReview.yml
+++ b/.github/workflows/SubmitReview.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   SubmitReview_job:
     name: Submit Review
-    runs-on: ubuntu-latest-large
+    runs-on: github-ubuntu-latest-s
     permissions:
       id-token: write
       pull-requests: read

--- a/.github/workflows/releasability.yml
+++ b/.github/workflows/releasability.yml
@@ -7,7 +7,7 @@ name: Releasability status
 
 jobs:
   update_releasability_status:
-    runs-on: ubuntu-latest-large
+    runs-on: github-ubuntu-latest-s
     name: Releasability status
     permissions:
       id-token: write


### PR DESCRIPTION
[BUILD-8875](https://sonarsource.atlassian.net/browse/BUILD-8875)

## GitHub Actions Runner Migration

This PR updates GitHub Actions workflows to use our new standardized runner naming convention.

### Changes
- Updates runner names in workflow files to new standardized format
- No functional changes to your CI/CD pipelines
- All existing functionality remains identical

### Runner Mappings
| Old Runner | New Runner |
|------------|------------|
| sonar-runner-large | github-ubuntu-latest-s |
| ubuntu-latest-large | github-ubuntu-latest-s |
| windows-latest-large | github-windows-latest-s |
| ubuntu-24.04-large | github-ubuntu-latest-s |
| sonar-runner-large-arm | github-ubuntu-24.04-arm-s |
| ubuntu-24.04-arm-large | github-ubuntu-24.04-arm-s |

### What You Need to Do
1. Review the changes in this PR
2. Merge when ready - no additional action required
3. Old runners will remain available during transition

### Additional Information
For more details about GitHub Actions runners and their specifications, see our [GitHub Actions Runner Documentation](https://xtranet-sonarsource.atlassian.net/wiki/spaces/Platform/pages/3694231566/GitHub+Actions+Runner+-+GitHub).

This is an automated migration. Questions? Contact the **Engineering Experience squad**.


[BUILD-8875]: https://sonarsource.atlassian.net/browse/BUILD-8875?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ