### PR TITLE
SCANPY-249 Default sonar.sources to current directory when not provided

### DIFF
--- a/src/pysonar_scanner/configuration/configuration_loader.py
+++ b/src/pysonar_scanner/configuration/configuration_loader.py
@@ -92,7 +92,10 @@ class ConfigurationLoader:
 
         sources_defaulted = SONAR_SOURCES not in resolved_properties
         if sources_defaulted:
-            logging.info("sonar.sources is not set; defaulting to the current directory '.'")
+            logging.info(
+                "sonar.sources is not set; defaulting to the current directory '.'. "
+                "Set sonar.sources explicitly to override this behavior."
+            )
             resolved_properties[SONAR_SOURCES] = "."
 
         if (sources_defaulted or tests_auto_detected) and SONAR_TESTS in resolved_properties:
@@ -103,7 +106,9 @@ class ConfigurationLoader:
                 f"{existing},{test_exclusion_patterns}" if existing else test_exclusion_patterns
             )
             logging.info(
-                "Adding test directories to sonar.exclusions to avoid overlap with sonar.sources: '%s'",
+                "Adding test directories to sonar.exclusions to avoid overlap with sonar.sources: '%s'. "
+                "To manage this manually, set sonar.sources to a path that does not include the test directories, "
+                "or set sonar.tests explicitly to disable auto-detection.",
                 test_exclusion_patterns,
             )
 

--- a/src/pysonar_scanner/configuration/configuration_loader.py
+++ b/src/pysonar_scanner/configuration/configuration_loader.py
@@ -28,6 +28,7 @@ from pysonar_scanner.configuration.properties import (
     SONAR_PROJECT_KEY,
     SONAR_TOKEN,
     SONAR_PROJECT_BASE_DIR,
+    SONAR_SOURCES,
     SONAR_TESTS,
     SONAR_PYTHON_TEST_FILE_HEURISTIC_DISABLED,
     Key,
@@ -85,6 +86,10 @@ class ConfigurationLoader:
             resolved_properties.update(inferred_props)
             if disable_heuristic and SONAR_PYTHON_TEST_FILE_HEURISTIC_DISABLED not in resolved_properties:
                 resolved_properties[SONAR_PYTHON_TEST_FILE_HEURISTIC_DISABLED] = "true"
+
+        if SONAR_SOURCES not in resolved_properties:
+            logging.info("sonar.sources is not set; defaulting to the current directory '.'")
+            resolved_properties[SONAR_SOURCES] = "."
 
         return resolved_properties
 

--- a/src/pysonar_scanner/configuration/configuration_loader.py
+++ b/src/pysonar_scanner/configuration/configuration_loader.py
@@ -28,6 +28,7 @@ from pysonar_scanner.configuration.properties import (
     SONAR_PROJECT_KEY,
     SONAR_TOKEN,
     SONAR_PROJECT_BASE_DIR,
+    SONAR_EXCLUSIONS,
     SONAR_SOURCES,
     SONAR_TESTS,
     SONAR_PYTHON_TEST_FILE_HEURISTIC_DISABLED,
@@ -81,15 +82,30 @@ class ConfigurationLoader:
         heuristic_disabled = (
             str(resolved_properties.get(SONAR_PYTHON_TEST_FILE_HEURISTIC_DISABLED, "")).lower() == "true"
         )
+        tests_auto_detected = False
         if SONAR_TESTS not in resolved_properties and not heuristic_disabled:
             inferred_props, disable_heuristic = test_paths_loader.load(base_dir)
             resolved_properties.update(inferred_props)
+            tests_auto_detected = SONAR_TESTS in resolved_properties
             if disable_heuristic and SONAR_PYTHON_TEST_FILE_HEURISTIC_DISABLED not in resolved_properties:
                 resolved_properties[SONAR_PYTHON_TEST_FILE_HEURISTIC_DISABLED] = "true"
 
-        if SONAR_SOURCES not in resolved_properties:
+        sources_defaulted = SONAR_SOURCES not in resolved_properties
+        if sources_defaulted:
             logging.info("sonar.sources is not set; defaulting to the current directory '.'")
             resolved_properties[SONAR_SOURCES] = "."
+
+        if (sources_defaulted or tests_auto_detected) and SONAR_TESTS in resolved_properties:
+            test_dirs = [d.strip() for d in resolved_properties[SONAR_TESTS].split(",") if d.strip()]
+            test_exclusion_patterns = ",".join(f"{d}/**" for d in test_dirs)
+            existing = resolved_properties.get(SONAR_EXCLUSIONS, "")
+            resolved_properties[SONAR_EXCLUSIONS] = (
+                f"{existing},{test_exclusion_patterns}" if existing else test_exclusion_patterns
+            )
+            logging.info(
+                "Adding test directories to sonar.exclusions to avoid overlap with sonar.sources: '%s'",
+                test_exclusion_patterns,
+            )
 
         return resolved_properties
 

--- a/tests/unit/test_configuration_loader.py
+++ b/tests/unit/test_configuration_loader.py
@@ -456,6 +456,33 @@ class TestConfigurationLoader(pyfakefs.TestCase):
         self.assertEqual(configuration[SONAR_SOURCES], "src")
 
     @patch("sys.argv", ["myscript.py"])
+    def test_default_sources_adds_test_dirs_to_exclusions(self, mock_get_os, mock_get_arch):
+        """When sonar.sources defaults to '.' and sonar.tests is set, test dirs must be excluded from sources."""
+        self.fs.create_dir("tests")
+        configuration = ConfigurationLoader.load()
+        self.assertEqual(configuration[SONAR_SOURCES], ".")
+        self.assertEqual(configuration[SONAR_TESTS], "tests")
+        self.assertEqual(configuration[SONAR_EXCLUSIONS], "tests/**")
+
+    @patch("sys.argv", ["myscript.py"])
+    def test_default_sources_appends_test_dirs_to_existing_exclusions(self, mock_get_os, mock_get_arch):
+        """When sonar.exclusions is already set, test dirs are appended rather than replacing it."""
+        self.fs.create_dir("tests")
+        self.fs.create_file("sonar-project.properties", contents="sonar.exclusions=generated/**\n")
+        configuration = ConfigurationLoader.load()
+        self.assertEqual(configuration[SONAR_SOURCES], ".")
+        self.assertEqual(configuration[SONAR_EXCLUSIONS], "generated/**,tests/**")
+
+    @patch("sys.argv", ["myscript.py", "--sonar-sources", "."])
+    def test_auto_detected_tests_add_exclusions_even_when_sources_explicit(self, mock_get_os, mock_get_arch):
+        """Auto-detected test dirs are added to sonar.exclusions even when sonar.sources was explicitly set."""
+        self.fs.create_dir("tests")
+        configuration = ConfigurationLoader.load()
+        self.assertEqual(configuration[SONAR_SOURCES], ".")
+        self.assertEqual(configuration[SONAR_TESTS], "tests")
+        self.assertEqual(configuration[SONAR_EXCLUSIONS], "tests/**")
+
+    @patch("sys.argv", ["myscript.py"])
     def test_sonar_project_properties_sonar_tests_overrides_auto_detection(self, mock_get_os, mock_get_arch):
         """sonar.tests in sonar-project.properties must override auto-detected value from filesystem/pytest config."""
         self.fs.create_dir("tests")  # auto-detection would find this

--- a/tests/unit/test_configuration_loader.py
+++ b/tests/unit/test_configuration_loader.py
@@ -79,6 +79,7 @@ class TestConfigurationLoader(pyfakefs.TestCase):
         expected_configuration = {
             SONAR_TOKEN: "myToken",
             SONAR_PROJECT_KEY: "myProjectKey",
+            SONAR_SOURCES: ".",
             SONAR_SCANNER_APP: "python",
             SONAR_SCANNER_APP_VERSION: "1.0",
             SONAR_SCANNER_BOOTSTRAP_START_TIME: configuration[SONAR_SCANNER_BOOTSTRAP_START_TIME],
@@ -103,7 +104,7 @@ class TestConfigurationLoader(pyfakefs.TestCase):
         self, get_static_default_properties_mock, mock_load, mock_get_os, mock_get_arch
     ):
         config = ConfigurationLoader.load()
-        self.assertDictEqual(config, {})
+        self.assertDictEqual(config, {SONAR_SOURCES: "."})
 
     @patch("pysonar_scanner.configuration.configuration_loader.get_static_default_properties", return_value={})
     @patch("sys.argv", ["myscript.py"])
@@ -115,6 +116,7 @@ class TestConfigurationLoader(pyfakefs.TestCase):
                 SONAR_PROJECT_BASE_DIR: os.getcwd(),
                 SONAR_SCANNER_OS: Os.LINUX.value,
                 SONAR_SCANNER_ARCH: Arch.X64.value,
+                SONAR_SOURCES: ".",
             },
         )
 
@@ -404,6 +406,7 @@ class TestConfigurationLoader(pyfakefs.TestCase):
             SONAR_SCANNER_OS: Os.LINUX.value,
             SONAR_SCANNER_ARCH: Arch.X64.value,
             SONAR_COVERAGE_EXCLUSIONS: "*/.local/*, /usr/*, utils/tirefire.py",
+            SONAR_SOURCES: ".",
             SONAR_SCANNER_DRY_RUN: False,
         }
         self.assertDictEqual(configuration, expected_configuration)
@@ -439,6 +442,18 @@ class TestConfigurationLoader(pyfakefs.TestCase):
         )
         configuration = ConfigurationLoader.load()
         self.assertEqual(configuration[SONAR_TESTS], "src/test")
+
+    @patch("sys.argv", ["myscript.py"])
+    def test_default_sources_when_not_set(self, mock_get_os, mock_get_arch):
+        """sonar.sources defaults to '.' when not set in any configuration source."""
+        configuration = ConfigurationLoader.load()
+        self.assertEqual(configuration[SONAR_SOURCES], ".")
+
+    @patch("sys.argv", ["myscript.py", "--sonar-sources", "src"])
+    def test_explicit_sources_overrides_default(self, mock_get_os, mock_get_arch):
+        """An explicit sonar.sources must not be overridden by the default."""
+        configuration = ConfigurationLoader.load()
+        self.assertEqual(configuration[SONAR_SOURCES], "src")
 
     @patch("sys.argv", ["myscript.py"])
     def test_sonar_project_properties_sonar_tests_overrides_auto_detection(self, mock_get_os, mock_get_arch):


### PR DESCRIPTION
----
## Summary by Gitar

- **Default sonar.sources:**
  - When `sonar.sources` is not provided, defaults to current directory `'.'`
- **Test directory exclusions:**
  - Auto-detected or explicitly set test directories are added to `sonar.exclusions` to prevent overlap with `sonar.sources`
  - Existing exclusions are preserved and appended to

<sub>This will update automatically on new commits.</sub>