### PR TITLE
SCANPY-259 Refactor API download exception tests

### DIFF
--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -337,21 +337,19 @@ class TestSonarQubeApi(unittest.TestCase):
 
             self.assertEqual(fake_file.getvalue(), file_content)
 
-        with (
-            self.subTest("download_analysis_engine returns 404"),
-            sq_api_mocker() as mocker,
-            self.assertRaises(SonarQubeApiException),
-        ):
+        with self.subTest("download_analysis_engine returns 404"), sq_api_mocker() as mocker:
             mocker.mock_analysis_engine_download(status=404)
-            self.sq.download_analysis_engine(io.BytesIO())
+            fake_file = io.BytesIO()
 
-        with (
-            self.subTest("download_analysis_engine: requests throws exception"),
-            sq_api_mocker() as mocker,
-            self.assertRaises(SonarQubeApiException),
-        ):
+            with self.assertRaises(SonarQubeApiException):
+                self.sq.download_analysis_engine(fake_file)
+
+        with self.subTest("download_analysis_engine: requests throws exception"), sq_api_mocker() as mocker:
+            fake_file = io.BytesIO()
+
             # since the api is not mocked, requests will throw an exception
-            self.sq.download_analysis_engine(io.BytesIO())
+            with self.assertRaises(SonarQubeApiException):
+                self.sq.download_analysis_engine(fake_file)
 
     def test_get_analysis_jres(self):
         expected_jres: list[JRE] = [
@@ -435,21 +433,19 @@ class TestSonarQubeApi(unittest.TestCase):
 
             self.assertEqual(fake_file.getvalue(), jre_file_content)
 
-        with (
-            self.subTest("download_analysis_jre returns 404"),
-            sq_api_mocker() as mocker,
-            self.assertRaises(SonarQubeApiException),
-        ):
+        with self.subTest("download_analysis_jre returns 404"), sq_api_mocker() as mocker:
             mocker.mock_analysis_jre_download(id=jre_id, status=404)
-            self.sq.download_analysis_jre(jre_id, io.BytesIO())
+            fake_file = io.BytesIO()
 
-        with (
-            self.subTest("download_analysis_jre: requests throws exception"),
-            sq_api_mocker() as mocker,
-            self.assertRaises(SonarQubeApiException),
-        ):
+            with self.assertRaises(SonarQubeApiException):
+                self.sq.download_analysis_jre(jre_id, fake_file)
+
+        with self.subTest("download_analysis_jre: requests throws exception"), sq_api_mocker() as mocker:
+            fake_file = io.BytesIO()
+
             # since the api is not mocked, requests will throw an exception
-            self.sq.download_analysis_jre(jre_id, io.BytesIO())
+            with self.assertRaises(SonarQubeApiException):
+                self.sq.download_analysis_jre(jre_id, fake_file)
 
     def test_download_file_from_url(self):
         jre_url = "https://sonarcloud.io/jres/OpenJDK17U-jre_x64_alpine-linux_hotspot_17.0.11_9.tar.gz"
@@ -462,21 +458,19 @@ class TestSonarQubeApi(unittest.TestCase):
 
             self.assertEqual(fake_file.getvalue(), jre_file_content)
 
-        with (
-            self.subTest("download_jre_from_url returns 404"),
-            sq_api_mocker() as mocker,
-            self.assertRaises(SonarQubeApiException),
-        ):
+        with self.subTest("download_jre_from_url returns 404"), sq_api_mocker() as mocker:
             mocker.mock_download_url(url=jre_url, status=404)
-            self.sq.download_file_from_url(jre_url, io.BytesIO())
+            fake_file = io.BytesIO()
 
-        with (
-            self.subTest("download_jre_from_url: requests throws exception"),
-            sq_api_mocker() as mocker,
-            self.assertRaises(SonarQubeApiException),
-        ):
+            with self.assertRaises(SonarQubeApiException):
+                self.sq.download_file_from_url(jre_url, fake_file)
+
+        with self.subTest("download_jre_from_url: requests throws exception"), sq_api_mocker() as mocker:
+            fake_file = io.BytesIO()
+
             # since the api is not mocked, requests will throw an exception
-            self.sq.download_file_from_url(jre_url, io.BytesIO())
+            with self.assertRaises(SonarQubeApiException):
+                self.sq.download_file_from_url(jre_url, fake_file)
 
     def test_to_api_configuration(self):
         with self.subTest("Missing keys"):


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Part of 
<!-- 
  Only for standalone PRs without Jira issue in the PR title: 
    * Replace this comment with Epic ID to create a new Task in Jira
    * Replace this comment with Issue ID to create a new Sub-Task in Jira
    * Ignore or delete this note to create a new Task in Jira without a parent 
-->

## Summary
- Move download test setup out of `assertRaises` contexts in API unit tests
- Reuse pre-created `BytesIO` handles so exception assertions contain only the API call under test

## Verification
- `python3 -m pytest tests/unit/test_api.py`
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://sonarsource.slack.com/archives/D0BA2FRD8TS/p1783501242624679?thread_ts=1783501242.624679&cid=D0BA2FRD8TS)

<div><a href="https://cursor.com/agents/bc-ab00962c-7d4c-52e2-866b-0539def74de5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ab00962c-7d4c-52e2-866b-0539def74de5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

